### PR TITLE
Simulator bounds and redef checking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "json.schemaDownload.enable": true,
   "rust-analyzer.linkedProjects": [
     "./mips/Cargo.toml",
     "./Cargo.toml",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tracking changes per date:
 
+## 230714
+
+- Added bounds checking for `Simulator` (`set_id_index`), panics on out of bounds.
+- Added re-definition check for `Simulator`, panics on re-definition.
+- Added units tests to the above.
+
 ## 230705
 
 - Refactoring of `Component` trait such that logic part is separated from GUI part.
@@ -15,7 +21,6 @@ Tracking changes per date:
 - `.gitignore` to exclude `.gv` and `.json` files.
 
 - `SignExtension` component.
-
 
 Compilation times might be annoying. It seems that under Linux there is a lot more dependencies than under Windows, so building `SyncRim` is faster on Win10 than under Linux (stock settings). There are a number of things to try out to reduce compilation times (and in particular `hot` iterations).
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -26,6 +26,7 @@ pub struct Simulator {
     // Components stored in topological evaluation order
     pub ordered_components: Components,
     pub sim_state: Vec<Signal>,
+    pub id_nr_outputs: IdNrOutputs,
     pub history: Vec<Vec<Signal>>,
     pub component_ids: Vec<String>,
     pub graph: Graph<String, ()>,
@@ -43,6 +44,8 @@ pub struct ComponentStore {
 // the first input is index 16
 // the second input is index 17, etc.
 pub type IdStartIndex = HashMap<String, usize>;
+
+pub type IdNrOutputs = HashMap<String, usize>;
 
 // Common functionality for all components
 #[typetag::serde(tag = "type")]


### PR DESCRIPTION
- Added bounds checking for `Simulator` (`set_id_index`), panics on out of bounds.
- Added re-definition check for `Simulator`, panics on re-definition.
- Added units tests to the above.