### PR TITLE
Vizia panes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "rust-analyzer.linkedProjects": [
     "./mips/Cargo.toml",
     "./Cargo.toml",
-    ".\\mips\\Cargo.toml"    
+    ".\\mips\\Cargo.toml"
   ],
   "cSpell.ignoreWords": [
     "Clippy",
@@ -12,6 +12,7 @@
     "Luleå",
     "Tpdf",
     "blueviolet",
+    "darkgray",
     "eframe",
     "egui",
     "epaint",
@@ -36,7 +37,7 @@
     "vizia",
     "winit",
     "xffff"
-  ],
+  ]
   //,
 
   // "rust-analyzer.cargo.unsetTest": [
@@ -44,5 +45,5 @@
   // ],
   // "rust-analyzer.cargo.noDefaultFeatures": true,
   // "rust-analyzer.cargo.features": ["gui-egui"]
-  // "rust-analyzer.cargo.features": ["components"] # use with nDefaultFeatures to just test 
+  // "rust-analyzer.cargo.features": ["components"] # use with nDefaultFeatures to just test
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracking changes per date:
 
+## 230718
+
+- Panes, right click component to display component interior on left panel. Close left panel view by the Close button.
+
 ## 230717
 
 - mips/reg_file update, showcasing interior mutability and gui_vizia poc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 members = ["mips"]
 
 [dependencies]
-clap = { version = "4.3.11", features = ["derive"] }
+clap = { version = "4.3.15", features = ["derive"] }
 fern = "0.6.2"
 log = "0.4.19"
 num_enum = "0.6.1"
 petgraph = "0.6.3"
 rfd = "0.11.4"
-serde = { version = "1.0.167", features = ["rc"] }
-serde_derive = "1.0.166"
-serde_json = "1.0.100"
-typetag = "0.2.9"
+serde = { version = "1.0.171", features = ["rc"] }
+serde_derive = "1.0.171"
+serde_json = "1.0.103"
+typetag = "0.2.10"
 
 
 [dependencies.vizia]

--- a/mips/Cargo.toml
+++ b/mips/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.167"
-serde_derive = "1.0.167"
-typetag = "0.2.9"
-serde_json = "1.0.100"
+serde = "1.0.171"
+serde_derive = "1.0.171"
+typetag = "0.2.10"
+serde_json = "1.0.103"
 fern = "0.6.2"
 log = "0.4.19"
 

--- a/mips/src/gui_vizia/components/instr_mem.rs
+++ b/mips/src/gui_vizia/components/instr_mem.rs
@@ -13,6 +13,14 @@ use log::*;
 #[typetag::serde]
 impl ViziaComponent for InstrMem {
     // create view
+    fn left_view(&self, cx: &mut Context) {
+        trace!("---- Create Left Instr View");
+        View::build(InstMemLeft { display: false }, cx, |cx| {
+            Label::new(cx, "Inst Mem Left");
+        });
+    }
+
+    // create view
     fn view(&self, cx: &mut Context) {
         trace!("---- Create InsrMem View");
         View::build(InstMem {}, cx, |cx| {
@@ -25,8 +33,35 @@ impl ViziaComponent for InstrMem {
         .top(Pixels(self.pos.1 - 100.0))
         .width(Pixels(100.0))
         .height(Pixels(200.0))
+        // .on_press(|cx| {
+        //     println!("press");
+        //     cx.emit(MemEvent::Hide)
+        // })
         .tooltip(|cx| new_component_tooltip(cx, self));
     }
+}
+
+#[derive(Lens, Clone)]
+pub struct InstMemLeft {
+    display: bool,
+}
+
+impl View for InstMemLeft {
+    fn element(&self) -> Option<&'static str> {
+        Some("InstMem")
+    }
+
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
+        event.map(|app_event, _meta| match app_event {
+            MemEvent::Hide => {
+                println!("got mem-event");
+            }
+        });
+    }
+}
+
+enum MemEvent {
+    Hide,
 }
 
 pub struct InstMem {}

--- a/mips/src/gui_vizia/components/instr_mem.rs
+++ b/mips/src/gui_vizia/components/instr_mem.rs
@@ -1,7 +1,7 @@
 use crate::components::InstrMem;
 use syncrim::{
     common::ViziaComponent,
-    gui_vizia::tooltip::new_component_tooltip,
+    gui_vizia::{tooltip::new_component_tooltip, GuiEvent},
     vizia::{
         prelude::*,
         vg::{Color, Paint, Path},
@@ -15,9 +15,16 @@ impl ViziaComponent for InstrMem {
     // create view
     fn left_view(&self, cx: &mut Context) {
         trace!("---- Create Left Instr View");
+        // HStack::new(cx, |cx| {
         View::build(InstMemLeft { display: false }, cx, |cx| {
             Label::new(cx, "Inst Mem Left");
         });
+        // Button::new(
+        //     cx,
+        //     |cx| cx.emit(GuiEvent::HideLeftPanel),
+        //     |cx| Label::new(cx, "Hide"),
+        // );
+        // });
     }
 
     // create view
@@ -73,7 +80,7 @@ impl View for InstMem {
 
     fn draw(&self, cx: &mut DrawContext<'_>, canvas: &mut Canvas) {
         let bounds = cx.bounds();
-        trace!("InstMem draw {:?}", bounds);
+        // trace!("InstMem draw {:?}", bounds);
 
         let mut path = Path::new();
         let mut paint = Paint::color(Color::rgbf(0.0, 1.0, 1.0));

--- a/mips/src/gui_vizia/components/instr_mem.rs
+++ b/mips/src/gui_vizia/components/instr_mem.rs
@@ -1,7 +1,7 @@
 use crate::components::InstrMem;
 use syncrim::{
     common::ViziaComponent,
-    gui_vizia::{tooltip::new_component_tooltip, GuiEvent},
+    gui_vizia::tooltip::new_component_tooltip,
     vizia::{
         prelude::*,
         vg::{Color, Paint, Path},
@@ -15,16 +15,10 @@ impl ViziaComponent for InstrMem {
     // create view
     fn left_view(&self, cx: &mut Context) {
         trace!("---- Create Left Instr View");
-        // HStack::new(cx, |cx| {
+
         View::build(InstMemLeft { display: false }, cx, |cx| {
             Label::new(cx, "Inst Mem Left");
         });
-        // Button::new(
-        //     cx,
-        //     |cx| cx.emit(GuiEvent::HideLeftPanel),
-        //     |cx| Label::new(cx, "Hide"),
-        // );
-        // });
     }
 
     // create view
@@ -40,10 +34,6 @@ impl ViziaComponent for InstrMem {
         .top(Pixels(self.pos.1 - 100.0))
         .width(Pixels(100.0))
         .height(Pixels(200.0))
-        // .on_press(|cx| {
-        //     println!("press");
-        //     cx.emit(MemEvent::Hide)
-        // })
         .tooltip(|cx| new_component_tooltip(cx, self));
     }
 }
@@ -58,17 +48,7 @@ impl View for InstMemLeft {
         Some("InstMem")
     }
 
-    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
-        event.map(|app_event, _meta| match app_event {
-            MemEvent::Hide => {
-                println!("got mem-event");
-            }
-        });
-    }
-}
-
-enum MemEvent {
-    Hide,
+    // TODO, what to show here
 }
 
 pub struct InstMem {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -68,6 +68,9 @@ pub trait Component {
 #[cfg(feature = "gui-vizia")]
 #[typetag::serde(tag = "type")]
 pub trait ViziaComponent: Component {
+    /// create left Vizia view
+    fn left_view(&self, _cx: &mut vizia::context::Context) {}
+
     /// create Vizia view
     fn view(&self, _cx: &mut vizia::context::Context) {}
 }

--- a/src/fern.rs
+++ b/src/fern.rs
@@ -15,7 +15,8 @@ pub fn fern_setup() {
             ))
         })
         // Add blanket level filter -
-        .level(log::LevelFilter::Debug);
+        // .level(log::LevelFilter::Debug);
+        .level(log::LevelFilter::Trace);
 
     // - and per-module overrides
     #[cfg(feature = "gui-vizia")]
@@ -23,6 +24,7 @@ pub fn fern_setup() {
         .level_for("vizia_core::systems::hover", LevelFilter::Info)
         .level_for("vizia_core::context", LevelFilter::Info)
         .level_for("cosmic_text::buffer", LevelFilter::Warn)
+        .level_for("cosmic_text", LevelFilter::Warn)
         .level_for("selectors::matching", LevelFilter::Warn)
         .level_for("cosmic_text::font::system::std", LevelFilter::Warn)
         .level_for("cosmic_text::font::fallback", LevelFilter::Warn);

--- a/src/fern.rs
+++ b/src/fern.rs
@@ -27,7 +27,9 @@ pub fn fern_setup() {
         .level_for("cosmic_text", LevelFilter::Warn)
         .level_for("selectors::matching", LevelFilter::Warn)
         .level_for("cosmic_text::font::system::std", LevelFilter::Warn)
-        .level_for("cosmic_text::font::fallback", LevelFilter::Warn);
+        .level_for("cosmic_text::font::fallback", LevelFilter::Warn)
+        .level_for("async_io::driver", LevelFilter::Warn);
+
     f
         // Output to stdout, files, and other Dispatch configurations
         .chain(std::io::stdout())

--- a/src/gui_vizia/components/add.rs
+++ b/src/gui_vizia/components/add.rs
@@ -24,6 +24,7 @@ impl ViziaComponent for Add {
                 .hoverable(false);
             NewPopup::new(cx, self.get_id_ports()).position_type(PositionType::SelfDirected);
         })
+        .position_type(PositionType::SelfDirected)
         .left(Pixels(self.pos.0 - 20.0))
         .top(Pixels(self.pos.1 - 40.0))
         .width(Pixels(40.0))

--- a/src/gui_vizia/gui.rs
+++ b/src/gui_vizia/gui.rs
@@ -130,18 +130,27 @@ pub fn gui(cs: &ComponentStore, path: &PathBuf) {
             .background_color(Color::lightgray())
             .height(Auto);
 
-            Grid::new(cx, |cx| {
-                // (re-)bind all components when simulator changed
-                Binding::new(
-                    cx,
-                    GuiData::simulator.then(Simulator::ordered_components),
-                    |cx, wrapper_oc| {
-                        let oc = wrapper_oc.get(cx);
-                        for c in oc {
-                            c.view(cx);
-                        }
-                    },
-                )
+            HStack::new(cx, |cx| {
+                // Left pane
+                Label::new(cx, "Left").top(Pixels(0.0));
+
+                // Grid area
+                Grid::new(cx, |cx| {
+                    // (re-)bind all components when simulator changed
+                    Binding::new(
+                        cx,
+                        GuiData::simulator.then(Simulator::ordered_components),
+                        |cx, wrapper_oc| {
+                            let oc = wrapper_oc.get(cx);
+                            for c in oc {
+                                c.view(cx);
+                            }
+                        },
+                    )
+                });
+
+                // Right pane
+                Label::new(cx, "Right").top(Pixels(0.0));
             });
 
             //

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -103,7 +103,8 @@ impl Simulator {
         }
 
         // topological order
-        let top = toposort(&graph, None).unwrap();
+        let top =
+            toposort(&graph, None).expect("Topological sort failed, your model contains loops.");
         trace!("--- top \n{:?}", top);
 
         let mut ordered_components = vec![];


### PR DESCRIPTION
A simple POC implementation of let, mid, right panes:

Push Right Button on any component, to get a left view pane of the component (defined a separate trait). Close an open left pane by the Close button. 

Not sure this is what we finally want, but its something at least. There are some limitations, just one open pane per component instance. Layout of the left pane is just a vertical layout. Size split between open panes. Much to improve on.

 