### PR TITLE
Add toolchain prefix clap flag to riscv example

### DIFF
--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -15,6 +15,7 @@ clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"
 fern = "0.6.2"
+xmas-elf = "0.9.0"
 
 [dependencies.syncrim]
 path = "../"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -10,8 +10,8 @@ serde = "1.0.167"
 serde_derive = "1.0.167"
 typetag = "0.2.9"
 serde_json = "1.0.100"
-riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
-#riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
+#riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
+riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
 clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -10,8 +10,7 @@ serde = "1.0.167"
 serde_derive = "1.0.167"
 typetag = "0.2.9"
 serde_json = "1.0.100"
-#riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
-riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
+riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
 clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -5,3 +5,6 @@ RISCV specific components.
 The ``riscv`` example will compile the assembly source file ``./asm.s``, link it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
 
 A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported.
+
+```cargo run --example riscv -- --toolchain-prefix=$PREFIX```
+Runs the simulation. On Linux, the --toolchain-prefix flag may be ommitted if the default ``riscv-gnu-toolchain`` is to be used.

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -1,10 +1,16 @@
 # RISCV
-
 RISCV specific components.
 
-The ``riscv`` example will compile the assembly source file ``./asm.s``, link it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
+```cargo run --example riscv```
+Runs the simulation with default settings.
 
-A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported.
+This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
 
-```cargo run --example riscv -- --toolchain-prefix=$PREFIX```
-Runs the simulation. On Linux, the --toolchain-prefix flag may be ommitted if the default ``riscv-gnu-toolchain`` is to be used.
+If the riscv toolchain is non-standard, the ``toolchain-prefix=$PREFIX`` can be used to change the toolchain prefix. By default, ``riscv32-unknown-elf-`` is used.
+
+A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported, so experiment!
+
+To provide your own source file or linker script, use ``asm-path=$ASM_PATH`` and ``ls-path=$LS_PATH`` respectively. The default values are ``asm.s`` and ``memory.x``.
+
+
+To skip compilation and linking, the ``use-elf`` flag can be used along with ``elf-path=$ELF_PATH`` to provide the simulation with an already compiled ELF file.

--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 // An example MIPS model
 use fern;
 use riscv::components::*;
@@ -13,9 +14,19 @@ use syncrim::{
     components::*,
 };
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to source file
+    #[arg(short, long, default_value = "riscv32-unknown-elf-")]
+    toolchain_prefix: String,
+}
+
 fn main() {
     fern_setup_riscv();
-    let memory = riscv_elf_parse::Memory::new_from_assembly("asm.s", "memory.x");
+    let args = Args::parse();
+    let memory =
+        riscv_elf_parse::Memory::new_from_assembly("asm.s", "memory.x", &args.toolchain_prefix);
     println!("{}", memory);
     let mut instr_mem = BTreeMap::new();
     let mut data_mem = HashMap::new();


### PR DESCRIPTION
This adds a toolchain prefix clap flag to the riscv example. The ``riscv32-unknown-elf-`` default may be overridden via `` --toolchain-prefix=$PREFIX `` if need be.