### PR TITLE
Add clap flags to the riscv example

### DIFF
--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -15,6 +15,7 @@ clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"
 fern = "0.6.2"
+xmas-elf = "0.9.0"
 
 [dependencies.syncrim]
 path = "../"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -10,8 +10,8 @@ serde = "1.0.167"
 serde_derive = "1.0.167"
 typetag = "0.2.9"
 serde_json = "1.0.100"
-riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
-#riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
+#riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
+riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
 clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -10,8 +10,7 @@ serde = "1.0.167"
 serde_derive = "1.0.167"
 typetag = "0.2.9"
 serde_json = "1.0.100"
-#riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
-riscv-elf-parse = {path = '/home/pawel/riscv-elf-parse'}
+riscv-elf-parse = {git = 'https://github.com/onsdagens/riscv-elf-parse'}
 clap = {version="4.3.11",features=["derive"]}
 log = "0.4.19"
 num_enum = "0.6.1"

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -5,3 +5,6 @@ RISCV specific components.
 The ``riscv`` example will compile the assembly source file ``./asm.s``, link it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
 
 A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported.
+
+```cargo run --example riscv -- --toolchain-prefix=$PREFIX```
+Runs the simulation. On Linux, the --toolchain-prefix flag may be ommitted if the default ``riscv-gnu-toolchain`` is to be used.

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -4,11 +4,11 @@ RISCV specific components.
 ```cargo run --example riscv```
 Runs the simulation with default settings.
 
-This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
+This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initializing the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
 
-If the riscv toolchain is non-standard, the ``toolchain-prefix=$PREFIX`` can be used to change the toolchain prefix. By default, ``riscv32-unknown-elf-`` is used.
+If the riscv toolchain on your machine uses non-standard naming, the ``toolchain-prefix=$PREFIX`` can be used to change the toolchain prefix. By default, ``riscv32-unknown-elf-`` is used.
 
-A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported, so experiment!
+A sample ``asm.s`` is provided, but any instructions except opcodes ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported, so experiment!
 
 To provide your own source file or linker script, use ``asm-path=$ASM_PATH`` and ``ls-path=$LS_PATH`` respectively. The default values are ``asm.s`` and ``memory.x``.
 

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -1,10 +1,16 @@
 # RISCV
-
 RISCV specific components.
 
-The ``riscv`` example will compile the assembly source file ``./asm.s``, link it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
+```cargo run --example riscv```
+Runs the simulation with default settings.
 
-A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported.
+This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initialize the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
 
-```cargo run --example riscv -- --toolchain-prefix=$PREFIX```
-Runs the simulation. On Linux, the --toolchain-prefix flag may be ommitted if the default ``riscv-gnu-toolchain`` is to be used.
+If the riscv toolchain is non-standard, the ``toolchain-prefix=$PREFIX`` can be used to change the toolchain prefix. By default, ``riscv32-unknown-elf-`` is used.
+
+A sample ``asm.s`` is provided, but any instructions except opcode ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported, so experiment!
+
+To provide your own source file or linker script, use ``asm-path=$ASM_PATH`` and ``ls-path=$LS_PATH`` respectively. The default values are ``asm.s`` and ``memory.x``.
+
+
+To skip compilation and linking, the ``use-elf`` flag can be used along with ``elf-path=$ELF_PATH`` to provide the simulation with an already compiled ELF file.

--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -17,21 +17,20 @@ use syncrim::{
 use xmas_elf::ElfFile;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
 struct Args {
-    /// Path to source file
+    /// Toolchain prefix to be used for compilation/linking
     #[arg(short, long, default_value = "riscv32-unknown-elf-")]
     toolchain_prefix: String,
-
+    /// Use a pre-compiled elf file instead of compiling one
     #[arg(short, long, default_value = "false")]
     use_elf: bool,
-
+    /// Path to the pre-compiled elf file
     #[arg(short, long, default_value = "")]
     elf_path: String,
-
+    /// Path to the assembly source file
     #[arg(short, long, default_value = "asm.s")]
     asm_path: String,
-
+    /// Path to the linker script
     #[arg(short, long, default_value = "memory.x")]
     ls_path: String,
 }
@@ -44,7 +43,11 @@ fn main() {
         let elf = ElfFile::new(&bytes).unwrap();
         riscv_elf_parse::Memory::new_from_elf(elf)
     } else {
-        riscv_elf_parse::Memory::new_from_assembly(&args.asm_path, &args.ls_path, &args.toolchain_prefix)
+        riscv_elf_parse::Memory::new_from_assembly(
+            &args.asm_path,
+            &args.ls_path,
+            &args.toolchain_prefix,
+        )
     };
     println!("{}", memory);
     let mut instr_mem = BTreeMap::new();

--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 // An example MIPS model
 use fern;
 use riscv::components::*;
@@ -13,9 +14,19 @@ use syncrim::{
     components::*,
 };
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to source file
+    #[arg(short, long, default_value = "riscv32-unknown-elf-")]
+    toolchain_prefix: String,
+}
+
 fn main() {
     fern_setup_riscv();
-    let memory = riscv_elf_parse::Memory::new_from_assembly("asm.s", "memory.x");
+    let args = Args::parse();
+    let memory =
+        riscv_elf_parse::Memory::new_from_assembly("asm.s", "memory.x", &args.toolchain_prefix);
     println!("{}", memory);
     let mut instr_mem = BTreeMap::new();
     let mut data_mem = HashMap::new();


### PR DESCRIPTION
This adds some flexibility to the RISC-V example.

The flag ``--toolchain-prefix=$PREFIX`` allows using toolchain with non-standard naming. The default is ``riscv32-unknown-elf-``

The flag ``--use-elf`` allows the user to provide a pre-compiled elf file. ``--elf-path=$ELF_PATH`` sets the path to the elf file. This is off by default.

Finally, ``--asm-path=$ASM_PATH`` and ``--ls-path=$LS_PATH`` allow the user to set the paths to the assembly source file and linker script respectively. The defaults are ``asm.s`` and ``memory.x``