### PR TITLE
Let cargo handle the compilation of RISC-V assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ Cargo.lock
 output.log
 
 riscv/*.o
+riscv/output
+
+riscv/riscv_asm/target/
+riscv/riscv_asm/memory.x
+riscv/riscv_asm/asm.s

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "repr",
     "rgbaf",
     "rgbf",
+    "riscv",
     "rustfmt",
     "serde",
     "stim",
@@ -47,7 +48,7 @@
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true
-  },
+  }
   //,
   // "rust-analyzer.cargo.unsetTest": [
   //   "syncrim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracking changes per date:
 
+## 230731
+
+- RISC-V cross compilation.
+
 ## 230727
 
 - `Signal` type now incorporates formatting. This allows the default formatting to be set on a signal on creation. The data and formatting can be read/written separately by setters/getters.

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -4,13 +4,10 @@ RISCV specific components.
 ```cargo run --example riscv```
 Runs the simulation with default settings.
 
-This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initializing the instruction and data memory accordingly. To that end, ``riscv-gnu-toolchain`` is a hard dependency.
-
-If the riscv toolchain on your machine uses non-standard naming, the ``toolchain-prefix=$PREFIX`` can be used to change the toolchain prefix. By default, ``riscv32-unknown-elf-`` is used.
+This means compiling the assembly source file ``./asm.s``, linking it using ``./memory.x`` , and initializing the instruction and data memory accordingly. This is all done using cargo, meaning no dependencies except the ``riscv32i-unknown-none-elf`` target. It may be installed via ``rustup target add riscv32i-unknown-none-elf``
 
 A sample ``asm.s`` is provided, but any instructions except opcodes ``CSR`` and ``MISC-MEM`` (so CSR read/writes and FENCE instructions) are supported, so experiment!
 
 To provide your own source file or linker script, use ``asm-path=$ASM_PATH`` and ``ls-path=$LS_PATH`` respectively. The default values are ``asm.s`` and ``memory.x``.
-
 
 To skip compilation and linking, the ``use-elf`` flag can be used along with ``elf-path=$ELF_PATH`` to provide the simulation with an already compiled ELF file.

--- a/riscv/asm.s
+++ b/riscv/asm.s
@@ -3,6 +3,7 @@
 start:
     lw x0, 0(x0)
     sw x1, 0(x1)
+l:  beq zero, zero, l
 
 .section .data 
 a:  .byte 0,1,2,3

--- a/riscv/asm.s
+++ b/riscv/asm.s
@@ -1,40 +1,9 @@
-.option arch, rv32i
 .section .text
-.section .init, "ax"
-.global _start
 
-_start:
-    li x30, 0xffff
-    sw x30, 0(x0)
-    lb x8, 0(x0)
-    addi x1, x0, 0 #x1=0
-    jal x2, .+8
-    jal x2, .+0 #this is to be jumped over or we will get stuck
-    jalr x2, x2, 4
-    jal x2, .+0 #this is to be jumped over or we will get stuck
-    addi x2, x0, 16
-    addi x1, x0, 0
-    addi x1, x1, 4
-    bne x1, x2, .-4
-    beq x1, x2, .+8
-    jal x0, .+0
-    addi x1, x0, -8
-    addi x2, x0, 0
-    addi x1, x1, 4
-    blt x1, x2, .-4
-    addi x1, x0, -8
-    addi x2, x0, 0
-    addi x1, x1, 4
-    bltu x2, x1, .-4
-    addi x1, x0, -8
-    addi x2, x0, 0
-    addi x1, x1, 4
-    bge x2, x1, .-4
-    addi x1, x0, -8
-    addi x2, x0, 8
-    addi x1, x1, 4
-    bgeu x1, x2, .-4
+start:
+    lw x0, 0(x0)
+    sw x1, 0(x1)
 
-.section .data
-msg:
-   .string "Hello World\n"
+.section .data 
+a:  .byte 0,1,2,3
+b:  .word 0,1,2,3

--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -323,6 +323,7 @@ fn main() {
                     Input::new("reg_file", "reg_b"),
                     Input::new("imm_szext", "out"),
                     Input::new("pc_adder", "out"),
+                    Input::new("reg", "out"),
                 ],
             ),
             Rc::new(ALU {

--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -8,7 +8,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fs,
     path::PathBuf,
-    rc::Rc,
+    rc::Rc, process::Command,
 };
 use syncrim::{
     common::{ComponentStore, Input},
@@ -18,9 +18,6 @@ use xmas_elf::ElfFile;
 
 #[derive(Parser, Debug)]
 struct Args {
-    /// Toolchain prefix to be used for compilation/linking
-    #[arg(short, long, default_value = "riscv32-unknown-elf-")]
-    toolchain_prefix: String,
     /// Use a pre-compiled elf file instead of compiling one
     #[arg(short, long, default_value = "false")]
     use_elf: bool,
@@ -38,17 +35,19 @@ struct Args {
 fn main() {
     fern_setup_riscv();
     let args = Args::parse();
-    let memory = if args.use_elf {
-        let bytes = fs::read(args.elf_path).expect("The elf file could not be found");
-        let elf = ElfFile::new(&bytes).unwrap();
-        riscv_elf_parse::Memory::new_from_elf(elf)
-    } else {
-        riscv_elf_parse::Memory::new_from_assembly(
-            &args.asm_path,
-            &args.ls_path,
-            &args.toolchain_prefix,
-        )
-    };
+    let memory =
+        if !args.use_elf{
+            elf_from_asm(&args);
+            let bytes = fs::read("./output").expect("The elf file could not be found");
+            let elf = ElfFile::new(&bytes).unwrap();
+            riscv_elf_parse::Memory::new_from_elf(elf)
+        }
+        else{
+            let bytes = fs::read(format!("{}", args.elf_path)).expect("The elf file could not be found");
+            let elf = ElfFile::new(&bytes).unwrap();
+            riscv_elf_parse::Memory::new_from_elf(elf)
+        };
+
     println!("{}", memory);
     let mut instr_mem = BTreeMap::new();
     let mut data_mem = HashMap::new();
@@ -140,86 +139,6 @@ fn main() {
                 pc: Input::new("reg", "out"),
                 // fake instructions just to show the relation between input address and instruction
                 bytes: instr_mem,
-                //vec![
-                //The results are calculated from the reg file start state defined above
-                //and assuming the blocks are the only code over that reg file.
-                //OP TEST BLOCK
-                // 0x003100b3,//add x1, x2, x3 -> x1 = 0x5
-                // 0x00308133,//add x2, x1, x3 -> x2 = 0x8
-                // 0x40410133,//sub x2, x2, x4 -> x2 = -2
-                // 0x004121b3,//slt x3, x2, x4 -> x3 = 0x1 //signed -2<10
-                // 0x004131b3,//sltu x3, x2, x4 x3 = 0x0 //unsigned -2>10
-                // 0x001151b3,//srl x3, x2, x1 # x3 = 0x07ffffff
-                // 0x401151b3,//sra x3, x2, x1 # x3 = 0xffffffff
-                // 0x001111b3,//sll x3, x2, x1 # x3 = 0xffffffc0
-                // 0x0020c1b3,//xor x3, x1, x2 # x3 = 0xfffffffb //fel här
-                // 0x0020f1b3,//and x3, x1, x2 # x3 = 0x00000004
-                // 0x0060e1b3,//or x3, x1, x6 #  x3 = 0x00000007
-                // 0x00000033,//add x0, x0, x0, basically nop before panicking so we can see result.
-                // 0x00940023,//sb x8, 0(x9) # should panic over opcode for now
-                //OP_IMM, AUIPC, LUI, STORE, LOAD, OP_IMM TEST BLOCK
-                // 0x00310093,//addi x1, x2, 3 # x1=0x5
-                // 0xffd0a093,//slti x1, x1, -3 # x1=0x0
-                // 0x0030a093,//slti x1, x1, 3 # x1=0x1
-                // 0xffd0b093,//sltiu x1, x1, -3 #x1=0x1
-                // 0x00313093,//sltiu x1, x2, 3 #x1=0x1
-                // 0x00324093,//xori x1, x4, 3 #x1 = 0x9
-                // 0x00326093,//ori x1, x4, 3 #x1=0xb
-                // 0x00327093,//andi x1, x4, 3 #x1=0x2
-                // 0x00c19093,//slli x1, x3, 12 #x1=0x3000
-                // 0x0011d093,//srli x1, x3, 1 #x1=0x1
-                // 0xffa00093,//addi x1, x0, -6 #x1=0xfffffffa
-                // 0x4020d093,//srai x1, x1, 2 #x1=0xfffffffe
-                // 0x00500093,//addi x1, x0, 5 #x1=0x5
-                // 0x4020d093,//srai x1, x1, 2 #x1=0x1
-                // 0xfffff0b7,//lui x1, 0xFFFFF #x1=0xFFFFF000
-                // 0xfffff097,//auipc x1, 0xFFFFF #x1=0xFFFFF040
-                // 0x00000093,//addi, x1, x0, 0 x1 = 0
-                // 0x00408093,//addi x1, x1, 4 x1+=4
-                // //0xff9ff16f,//jal, x2, -8 should jump to the addi before and keep incrementing x1.
-                // 0x00000033,//add x0, x0, x0, basically nop before panicking so we can see result.
-                // //0x00940023,//sb x8, 0(x9) # should panic over opcode for now
-                // 0x00102023,//sw x1, 0(x0) store x1=4 at 0
-                // 0x00002283,//lw x5, 0(x0) x5=4
-                // 0x00228213,//addi x4, x5, 2 //x4=6
-                // 0x00002303, //lw x6, 0(x0), x6 = 4
-                // 0xfff00093,//set x1 to -1 addi x1, x0, -1
-                // 0x00102023,//store -1 at 0
-                // 0x00000203,//load via lb -1 to x4
-                // 0x00004203,//lbu x4 -1 again.
-                // 0x004002a3,//sb x4, 5(0)
-                // 0x00000033,//add x0, x0, x0, basically nop before panicking so we can see result.
-                // 0x00000033,//add x0, x0, x0, basically nop before panicking so we can see result.
-                //JAL, JALR, BRANCHES TEST BLOCK
-                //     0x00000093, //addi, x1, x0, 0 x1=0
-                //     0x0080016f, //jal x2, 8
-                //     0x0000016f, //jal x2, 0 this is to be jumped over or we will get stuck
-                //     0x00410167, //jalr x2, x2, 4
-                //     0x0000016f, //jal x2, 0 this is to be jumped over or we will get stuck
-                //     0x01000113, //addi x2, x0, 16
-                //     0x00000093, //addi x1, x0, 0
-                //     0x00408093, //addi x1, x1, 4
-                //     0xfe209ee3, //bne x1, x2, -4
-                //     0x00208463, //beq, x1, x2, 8
-                //     0x0000006f, //jal x0, 0
-                //     0xff800093, //addi x1, x0, -8
-                //     0x00000113, //addi x2, x0, 0
-                //     0x00408093, //addi x1, x1, 4
-                //     0xfe20cee3, //blt x1, x2, -4
-                //     0xff800093, //addi x1, x0, -8
-                //     0x00000113, //addi x2, x0, 0
-                //     0x00408093, //addi x1, x1, 4
-                //     0xfe116ee3, //bltu, x2, x1, -4
-                //     0xff800093, //addi x1, x0, -8
-                //     0x00000113, //addi x2, x0, 0
-                //     0x00408093, //addi x1, x1, 4
-                //     0xfe115ee3, //bge x2, x1, -4
-                //     0xff800093, //addi x1, x0, -8
-                //     0x00800113, //addi x2, x0, 8
-                //     0x00408093, //addi x1, x1, 4
-                //     0xfe20fee3, //bgeu x1, x2, -4
-                //     0x00408093, 0x00408093, 0x00408093, 0x00408093, 4, 5, 6, 7, 8, 9,
-                // ],
             }),
             Rc::new(Decoder {
                 id: "decoder".to_string(),
@@ -252,43 +171,7 @@ fn main() {
                 write_data: Input::new("wb_mux", "out"),
                 write_addr: Input::new("regfile_rd_reg", "out"),
                 write_enable: Input::new("regfile_we_reg", "out"),
-                registers: RegStore::new(Rc::new(RefCell::new([
-                    0, 1, 2, 3, 10, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ]))),
-                // registers: vec![Cell::new(0),
-                // RefCell::new(1),
-                // Cell::new(2),
-                // Cell::new(3),
-                // Cell::new(10),
-                // Cell::new(5),
-                // Cell::new(6),
-                // Cell::new(7),
-                // Cell::new(8),
-                // Cell::new(9),
-                // Cell::new(10),
-                // Cell::new(11),
-                // Cell::new(12),
-                // Cell::new(13),
-                // Cell::new(14),
-                // Cell::new(15),
-                // Cell::new(16),
-                // Cell::new(17),
-                // Cell::new(18),
-                // Cell::new(19),
-                // Cell::new(20),
-                // Cell::new(21),
-                // Cell::new(22),
-                // Cell::new(23),
-                // Cell::new(24),
-                // Cell::new(25),
-                // Cell::new(26),
-                // Cell::new(27),
-                // Cell::new(28),
-                // Cell::new(29),
-                // Cell::new(30),
-                // Cell::new(31),
-                // ],
+                registers: RegStore::new(Rc::new(RefCell::new([0;32]))),
                 history: RegHistory::new(),
             }),
             Mem::rc_new_from_bytes(
@@ -385,4 +268,65 @@ fn fern_setup_riscv() {
         // Apply globally
         .apply()
         .unwrap()
+}
+
+fn elf_from_asm(args: &Args){
+    let source_path = &args.asm_path;
+    let linker_path = &args.ls_path;
+    let _ = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+                .current_dir(".\\")
+                .args(["/C", &format!("copy {} .\\riscv_asm\\asm.s", source_path)])
+                .status()
+                .unwrap()
+    } else {
+        Command::new("sh")
+                .current_dir("./")
+                .arg("-c")
+                .arg(format!("cp {} ./riscv_asm/asm.s", source_path))
+                .status()
+                .unwrap()
+    };
+    let _ = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+                .current_dir(".\\")
+                .args(["/C", &format!("copy {} .\\riscv_asm\\memory.x", linker_path)])
+                .status()
+                .unwrap()
+    } else {
+        Command::new("sh")
+                .current_dir("./")
+                .arg("-c")
+                .arg(format!("cp {} ./riscv_asm/memory.x", linker_path))
+                .status()
+                .unwrap()
+    };
+    let _ = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+                .current_dir(".\\riscv_asm\\")
+                .args(["/C", "cargo build --release"])
+                .status()
+                .unwrap()
+    } else {
+        Command::new("sh")
+                .current_dir("./riscv_asm/")
+                .arg("-c")
+                .arg(format!("cargo build --release"))
+                .status()
+                .unwrap()    
+    };
+    let _ = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+                .current_dir(".\\riscv_asm\\")
+                .args(["/C", "move /y .\\target\\riscv32i-unknown-none-elf\\release\\riscv_asm ..\\output"])
+                .status()
+                .unwrap()
+    } else {
+        Command::new("sh")
+                .current_dir("./")
+                .arg("-c")
+                .arg(format!("mv ./riscv_asm/target/riscv32i-unknown-none-elf/release/riscv_asm ./output"))
+                .status()
+                .unwrap()
+    };
 }

--- a/riscv/memory.x
+++ b/riscv/memory.x
@@ -1,7 +1,14 @@
 SECTIONS
 {
-   . = 0x0;
-   .text : { *(.init) }
-   . = 0x80000000;
-   .data : { *(.data) }
+  . = 0x0;
+  .text :
+  {
+    KEEP(*(.text)); 
+  }
+
+  . = 0x1000;
+  .data :
+  {
+    KEEP(*(.data));  
+  } 
 }

--- a/riscv/memory.x
+++ b/riscv/memory.x
@@ -6,7 +6,7 @@ SECTIONS
     KEEP(*(.text)); 
   }
 
-  . = 0x1000;
+  . = 0x50000000;
   .data :
   {
     KEEP(*(.data));  

--- a/riscv/riscv_asm/.cargo/config.toml
+++ b/riscv/riscv_asm/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.riscv32i-unknown-none-elf]
+
+rustflags = [
+    # LLD (shipped with the Rust toolchain) is used as the default linker
+    "-C",
+    "link-arg=-Tmemory.x",
+]
+
+[build]
+target = "riscv32i-unknown-none-elf"

--- a/riscv/riscv_asm/Cargo.toml
+++ b/riscv/riscv_asm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "riscv_asm"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# crate_type = ["staticlib"]
+
+[dependencies]
+# cc = "1.0.79"
+
+[workspace]

--- a/riscv/riscv_asm/README.md
+++ b/riscv/riscv_asm/README.md
@@ -1,0 +1,39 @@
+# riscv_asm
+
+Experiment to check if we can do assembly programming in an easy way using the Rust toolchain only.
+
+## Installation
+
+- Rust installed.
+
+- RISCV backend.
+  
+- Rust LLVM tools distribution (you can also use any llvm or gnu counterpart)
+
+- [Cargo binutils](https://github.com/rust-embedded/cargo-binutils) for easy integration.
+
+```shell
+rustup target add riscv32i-unknown-none-elf
+rustup component add llvm-tools 
+cargo install cargo-binutils
+```
+
+## Example
+
+To build a binary.
+
+```shell
+cargo build 
+```
+
+To disassemble the generated binary.
+
+```shell
+cargo objdump -- --disassemble --print-imm-hex
+```
+
+To get size information and layout for sections and symbols.
+
+```shell
+cargo nm
+```

--- a/riscv/riscv_asm/build.rs
+++ b/riscv/riscv_asm/build.rs
@@ -1,0 +1,5 @@
+// fn main() {
+//     cc::Build::new().file("foo.c").file("bar.c").compile("foo");
+// }
+
+fn main() {}

--- a/riscv/riscv_asm/build.rs
+++ b/riscv/riscv_asm/build.rs
@@ -1,5 +1,0 @@
-// fn main() {
-//     cc::Build::new().file("foo.c").file("bar.c").compile("foo");
-// }
-
-fn main() {}

--- a/riscv/riscv_asm/src/main.rs
+++ b/riscv/riscv_asm/src/main.rs
@@ -1,0 +1,14 @@
+#![no_std]
+#![no_main]
+use core::arch::global_asm;
+
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+global_asm! {
+    include_str!("../asm.s")
+}

--- a/riscv/src/components/decoder.rs
+++ b/riscv/src/components/decoder.rs
@@ -1660,7 +1660,7 @@ mod test {
         simulator.clock();
         assert_eq!(simulator.get_input_value(wb_mux), 0.into());
         assert_eq!(simulator.get_input_value(alu_operand_a_sel), 1.into());
-        assert_eq!(simulator.get_input_value(alu_operand_b_sel), 2.into());
+        assert_eq!(simulator.get_input_value(alu_operand_b_sel), 3.into());
         assert_eq!(
             simulator.get_input_value(regfile_rs1),
             SignalValue::Uninitialized

--- a/riscv/src/components/decoder.rs
+++ b/riscv/src/components/decoder.rs
@@ -277,7 +277,7 @@ impl Component for Decoder {
                 //AUIPC
                 trace!("opcode=AUIPC");
                 alu_operand_a_sel = SignalValue::from(1); //big-imm
-                alu_operand_b_sel = SignalValue::from(2); //PC
+                alu_operand_b_sel = SignalValue::from(3); //PC
                 regfile_rd = SignalValue::from((instruction & (0b11111 << 7)) >> 7);
                 //regfile_rs1 = SignalValue::from(0); //x0 dont care
                 regfile_we = SignalValue::from(1); //enable write

--- a/src/components/mem.rs
+++ b/src/components/mem.rs
@@ -87,6 +87,7 @@ impl Mem {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn rc_new_from_bytes(
         id: &str,
         pos: (f32, f32),


### PR DESCRIPTION
This adds a binary crate courtesy of @perlindgren which allows us to use cargo to compile the provided RISC-V assembly.

The solution is really funky, via Commands we copy the source file and linker script into the ``./riscv_asm`` binary crate, compile it with ``cargo build --release`` , then move the compilation results back into ``./`` .

The binary crate consists of basically ``global_asm!(include_str!("<ASM_SOURCE_FILE_PATH>"))``, and a rustc flag to use the linker script.

I tried making it Windows compatible, but am unable to test it, so would appreciate some help there.