### PR TITLE
run halt modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracking changes per date:
 
+## 230801
+
+- Simulator run/halt is implemented in `vizia` using a simple eventing mechanism. Later we might want to spawn a simulation thread for faster execution (right now its tied to frame rate).
+
 ## 230731
 
 - Return type from `clock` (`fn clock(&self, _simulator: &mut Simulator) -> Result<(), Condition`).

--- a/examples/probe_stim_assert.rs
+++ b/examples/probe_stim_assert.rs
@@ -9,12 +9,12 @@ fn main() {
     fern_setup();
     let cs = ComponentStore {
         store: vec![
-            ProbeStim::rc_new("stim", (100.0, 100.0), vec![42, 1, 2]),
+            ProbeStim::rc_new("stim", (100.0, 100.0), vec![0, 1, 2, 3, 1337]),
             ProbeAssert::rc_new(
                 "assert",
                 (200.0, 100.0),
                 Input::new("stim", "out"),
-                vec![0, 1, 2],
+                vec![0, 1, 2, 3, 42],
             ),
         ],
     };

--- a/src/common.rs
+++ b/src/common.rs
@@ -33,6 +33,8 @@ pub struct Simulator {
     pub history: Vec<Vec<Signal>>,
     pub component_ids: Vec<Id>,
     pub graph: Graph<Id, ()>,
+    // Running state, (do we need it accessible from other crates?)
+    pub(crate) running: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/components/probe_assert.rs
+++ b/src/components/probe_assert.rs
@@ -1,4 +1,7 @@
-use crate::common::{Component, Condition, Id, Input, OutputType, Ports, Signal, Simulator};
+use crate::{
+    common::{Component, Condition, Id, Input, OutputType, Ports, Signal, Simulator},
+    signal::SignalValue,
+};
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
@@ -27,7 +30,10 @@ impl Component for ProbeAssert {
     fn clock(&self, simulator: &mut Simulator) -> Result<(), Condition> {
         trace!("-- cycle {} --", simulator.cycle);
         let lhs = simulator.get_input_value(&self.input);
-        let rhs = self.values[simulator.cycle].get_value();
+        let rhs = match self.values.get(simulator.cycle) {
+            Some(rhs) => rhs.get_value(),
+            _ => SignalValue::Unknown,
+        };
 
         // the assertion is checked only in test mode
         #[cfg(test)]

--- a/src/gui_vizia/transport.rs
+++ b/src/gui_vizia/transport.rs
@@ -1,6 +1,6 @@
+use crate::common::Simulator;
 use crate::gui_vizia::{GuiData, GuiEvent};
 use vizia::{icons, prelude::*};
-
 pub(crate) struct Transport {}
 
 impl View for Transport {}
@@ -58,11 +58,11 @@ impl Transport {
                     |cx| {
                         Label::new(
                             cx,
-                            GuiData::pause.map(|pause| {
-                                if *pause {
-                                    icons::ICON_PLAYER_PLAY
-                                } else {
+                            GuiData::simulator.then(Simulator::running).map(|running| {
+                                if *running {
                                     icons::ICON_PLAYER_PLAY_FILLED
+                                } else {
+                                    icons::ICON_PLAYER_PLAY
                                 }
                             }),
                         )
@@ -84,11 +84,11 @@ impl Transport {
                     |cx| {
                         Label::new(
                             cx,
-                            GuiData::pause.map(|pause| {
-                                if *pause {
-                                    icons::ICON_PLAYER_PAUSE_FILLED
-                                } else {
+                            GuiData::simulator.then(Simulator::running).map(|running| {
+                                if *running {
                                     icons::ICON_PLAYER_PAUSE
+                                } else {
+                                    icons::ICON_PLAYER_PAUSE_FILLED
                                 }
                             }),
                         )

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -229,7 +229,10 @@ impl Simulator {
                 Err(cond) => match cond {
                     Condition::Warning(warn) => trace!("warning {}", warn),
                     Condition::Error(err) => panic!("err {}", err),
-                    Condition::Assert(assert) => panic!("assert {}", assert),
+                    Condition::Assert(assert) => {
+                        error!("assertion failed {}", assert);
+                        self.running = false;
+                    }
                     Condition::Halt(halt) => {
                         self.running = false;
                         info!("halt {}", halt)

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -136,6 +136,7 @@ impl Simulator {
             history: vec![],
             component_ids,
             graph,
+            running: false,
         };
 
         trace!("sim_state {:?}", simulator.sim_state);
@@ -226,14 +227,30 @@ impl Simulator {
             match component.clock(self) {
                 Ok(_) => {}
                 Err(cond) => match cond {
-                    Condition::Warning(_) => todo!(),
+                    Condition::Warning(warn) => trace!("warning {}", warn),
                     Condition::Error(err) => panic!("err {}", err),
                     Condition::Assert(assert) => panic!("assert {}", assert),
-                    Condition::Halt(halt) => info!("halt {}", halt),
+                    Condition::Halt(halt) => {
+                        self.running = false;
+                        info!("halt {}", halt)
+                    }
                 },
             }
         }
         self.cycle = self.history.len();
+    }
+
+    /// free running mode until Halt condition
+    pub fn run(&mut self) {
+        self.running = true;
+        while self.running {
+            self.clock()
+        }
+    }
+
+    /// stop the simulator from gui or other external reason
+    pub fn stop(&mut self) {
+        self.running = false;
     }
 
     /// reverse simulation using history if clock > 1
@@ -256,7 +273,12 @@ impl Simulator {
         self.history = vec![];
         self.cycle = 0;
         self.sim_state.iter_mut().for_each(|val| *val = 0.into());
+        self.stop();
         self.clock();
+    }
+
+    pub fn get_state(&self) -> bool {
+        self.running
     }
 
     /// save as `dot` file with `.gv` extension


### PR DESCRIPTION
Simple implementation using `vizia` gui eventing. This will tie the update frequency to frame rate, later we might want to decouple free-running simulation into a thread.
