### PR TITLE
Ensure Sequential output components come first in the sorted list

### DIFF
--- a/riscv/examples/riscv.rs
+++ b/riscv/examples/riscv.rs
@@ -34,13 +34,11 @@ fn main() {
     let memory = if !args.use_elf {
         elf_from_asm(&args);
         let bytes = fs::read("./output").expect("The elf file could not be found");
-        let elf = ElfFile::new(&bytes).unwrap();
-        riscv_elf_parse::Memory::new_from_elf(elf)
+        riscv_elf_parse::Memory::new_from_file(&bytes, true)
     } else {
         let bytes =
             fs::read(format!("{}", args.elf_path)).expect("The elf file could not be found");
-        let elf = ElfFile::new(&bytes).unwrap();
-        riscv_elf_parse::Memory::new_from_elf(elf)
+        riscv_elf_parse::Memory::new_from_file(&bytes, true)
     };
 
     println!("{}", memory);

--- a/src/gui_egui/components/wire.rs
+++ b/src/gui_egui/components/wire.rs
@@ -13,7 +13,6 @@ impl EguiComponent for Wire {
         _clip_rect: egui::Rect,
     ) {
         let oh: fn((f32, f32), f32, egui::Vec2) -> egui::Pos2 = offset_helper;
-        let offset = offset;
         let s = scale;
         let o = offset;
         let mut line_vec = vec![];

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -110,10 +110,22 @@ impl Simulator {
         trace!("--- topologically ordered graph \n{:?}", top);
 
         let mut ordered_components = vec![];
+        //two passes ensure the sorted list of nodes always starts with ALL of the roots
+        //first push the sequential components, eg. graph roots
         for node in &top {
             #[allow(suspicious_double_ref_op)]
             let c = (**node_comp.get(node).unwrap()).clone();
-            ordered_components.push(c);
+            if c.get_id_ports().1.out_type == OutputType::Sequential {
+                ordered_components.push(c);
+            }
+        }
+        //now push all of the other components
+        for node in &top {
+            #[allow(suspicious_double_ref_op)]
+            let c = (**node_comp.get(node).unwrap()).clone();
+            if c.get_id_ports().1.out_type == OutputType::Combinatorial {
+                ordered_components.push(c);
+            }
         }
 
         let component_ids: Vec<Id> = ordered_components


### PR DESCRIPTION
This fixes the inconsistencies we discussed offline.

Also, very minor change, adjusting the rv32i model example to a breaking change in a dependency.