### PR TITLE
Fixed order of reset and evaluation in simulator reset function

### DIFF
--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -309,15 +309,19 @@ impl Simulator {
 
     /// reset simulator
     pub fn reset(&mut self) {
+        // The order of the following is not important
+        // with the exception that self.clock() needs to be last
         self.history = vec![];
         self.cycle = 0;
-        self.sim_state.iter_mut().for_each(|val| *val = 0.into());
         self.stop();
-        self.clock();
+
+        self.sim_state.iter_mut().for_each(|val| *val = 0.into());
 
         for component in self.ordered_components.clone() {
             component.reset();
         }
+
+        self.clock();
     }
 
     pub fn get_state(&self) -> bool {


### PR DESCRIPTION
This fixes a problem with the order of operations in simulator reset.

The problem is that the the components are evaluated before reset is called,
which means they still have their old internal state. This fixes this by calling reset before the components are evaluated.
