### PR TITLE
Egui Uppdate and simulator state to keep track of component condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tracking changes per date:
 
+## 240911
+- Added so that simulator now tracks what component condition
+- Added simulator running state, such as running, halt or error
+- Added stepping functionality
+- Added functionality to gui to show running state and component condition
+
 ## 240909
 
 - Added un-clock history for set of active components

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ serde_derive = "1.0.171"
 serde_json = "1.0.103"
 typetag = "0.2.10"
 
-
 [dependencies.vizia]
 git = "https://github.com/vizia/vizia.git"
 #path = "../vizia"
@@ -29,7 +28,7 @@ optional = true
 
 [dependencies.egui]
 optional = true
-version = "0.23.0"
+version = "0.28.0"
 
 [dependencies.winapi]
 optional = true
@@ -38,11 +37,11 @@ features = ["winuser"]
 
 [dependencies.eframe]
 optional = true
-version = "0.23.0"
+version = "0.28.0"
 
 [dependencies.epaint]
 optional = true
-version = "0.23.0"
+version = "0.28.0"
 
 [features]
 default = ["gui-egui"]

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,7 @@ Each target (e.g. `mips`, has a separate `TODO.md`).
 - Better tooltips for components. (Complexity moderate.)
 
 - Better popups for components. (Complexity moderate.)
+
+## Egui
+
+- Add better formatted tooltip for probe, maybe use ``LayoutJob``, if style is not respected maybe force to ``galley`` (Complexity low, but weird egui stuff)

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.19"
 num_enum = "0.7.2"
 fern = "0.6.2"
 xmas-elf = "0.9.0"
-egui = "0.23.0"
+egui = "0.28.0"
 asm_riscv = { git = 'https://github.com/onsdagens/wari' }
 gimli = "0.27.3"
 object = "0.31.1"
@@ -24,7 +24,7 @@ memmap2 = "0.7.1"
 riscv_asm_strings = { git = 'https://github.com/perlindgren/riscv_asm_strings' }
 priority-queue = { version = "1.3.2", features = ["serde"] }
 riscv-rt = "0.11.0"
-egui_extras = "0.23.0"
+egui_extras = "0.28.0"
 
 [dependencies.syncrim]
 path = "../"

--- a/riscv/src/gui_egui/components/probe_label.rs
+++ b/riscv/src/gui_egui/components/probe_label.rs
@@ -29,7 +29,7 @@ impl EguiComponent for ProbeLabel {
             Some(s) => s.get_input_value(&input),
             None => SignalValue::Uninitialized,
         };
-        let area = Area::new(self.id.to_string())
+        let area = Area::new(self.id.clone().into())
             .order(Order::Middle)
             .current_pos(offset.to_pos2())
             .movable(false)

--- a/riscv/src/gui_egui/components/reg_file.rs
+++ b/riscv/src/gui_egui/components/reg_file.rs
@@ -124,7 +124,8 @@ impl EguiComponent for RegFile {
                                 15.0 * scale,
                                 RegStore::lo_range().end as usize
                                     - RegStore::lo_range().start as usize,
-                                |index, mut row| {
+                                |mut row| {
+                                    let index = row.index();
                                     row.col(|ui| {
                                         ui.add(Label::new(
                                             RichText::new(format!(

--- a/riscv/src/gui_egui/components/rv_mem.rs
+++ b/riscv/src/gui_egui/components/rv_mem.rs
@@ -36,8 +36,8 @@ impl RVMem {
                     body.rows(
                         15.0,
                         ((self.range.end - self.range.start) / 4) as usize,
-                        |index, mut row| {
-                            //println!("{}", index);
+                        |mut row| {
+                            let index = row.index();
                             let address = self.range.start as usize + index * 4;
                             let memory = self.memory.0.borrow().clone();
                             row.col(|ui| {
@@ -68,10 +68,10 @@ impl RVMem {
                                 }
                             }
                             row.col(|ui| {
-                                ui.add(Label::new(word).truncate(true));
+                                ui.add(Label::new(word).truncate());
                             });
                             row.col(|ui| {
-                                ui.add(Label::new(ascii).truncate(true));
+                                ui.add(Label::new(ascii).truncate());
                             });
                         },
                     );

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,6 +23,15 @@ type Components = Vec<Rc<dyn ViziaComponent>>;
 #[cfg(feature = "gui-egui")]
 pub type Components = Vec<Rc<dyn EguiComponent>>;
 
+#[derive(PartialEq, Clone)]
+pub enum RunningState {
+    Running,
+    StepTo(usize),
+    Halt,
+    Err,
+    Stopped,
+}
+
 #[cfg_attr(feature = "gui-vizia", derive(Lens))]
 #[derive(Clone)]
 pub struct Simulator {
@@ -37,8 +46,15 @@ pub struct Simulator {
     pub history: Vec<Vec<Signal>>,
     pub component_ids: Vec<Id>,
     pub graph: Graph<Id, ()>,
-    // Running state, (do we need it accessible from other crates?)
-    pub(crate) running: bool,
+
+    // if set to true, running state is set to Halt when a component returns Warning
+    // pub(crate) might not be needed but easier than implementing setters and getters
+    pub(crate) halt_on_warning: bool,
+    // says if simulation is running, halted, stopped or stepping to a specific cycle
+    pub running_state: RunningState,
+    // stores if components return a condition
+    // TODO add component condition history
+    pub component_condition: Vec<(Id, Condition)>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,7 +23,7 @@ type Components = Vec<Rc<dyn ViziaComponent>>;
 #[cfg(feature = "gui-egui")]
 pub type Components = Vec<Rc<dyn EguiComponent>>;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum RunningState {
     Running,
     StepTo(usize),

--- a/src/common.rs
+++ b/src/common.rs
@@ -58,9 +58,11 @@ pub struct Simulator {
     pub(crate) halt_on_warning: bool,
     // says if simulation is running, halted, stopped or stepping to a specific cycle
     pub running_state: RunningState,
+    pub running_state_history: Vec<RunningState>,
     // stores if components return a condition
     // TODO add component condition history
     pub component_condition: Vec<(Id, Condition)>,
+    pub component_condition_history: Vec<Vec<(Id, Condition)>>,
 
     // Used to determine active components
     pub sinks: Vec<Id>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -105,12 +105,12 @@ pub trait Component {
     fn as_any(&self) -> &dyn Any;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Condition {
     Warning(String),
-    Error(String),
-    Assert(String),
     Halt(String),
+    Assert(String),
+    Error(String),
 }
 
 #[cfg(feature = "gui-egui")]

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,6 +23,9 @@ type Components = Vec<Rc<dyn ViziaComponent>>;
 #[cfg(feature = "gui-egui")]
 pub type Components = Vec<Rc<dyn EguiComponent>>;
 
+pub enum SimulatorError {
+    RunningStateIsErr(),
+}
 #[derive(PartialEq, Clone, Debug)]
 pub enum RunningState {
     Running,

--- a/src/fern.rs
+++ b/src/fern.rs
@@ -32,6 +32,7 @@ pub fn fern_setup() {
 
     #[cfg(feature = "gui-egui")]
     let f = f
+        .level_for("eframe::native::glow_integration", LevelFilter::Info)
         .level_for("eframe::native::run", LevelFilter::Info)
         .level_for("async_io::driver", LevelFilter::Warn);
 

--- a/src/gui_egui/component_ui.rs
+++ b/src/gui_egui/component_ui.rs
@@ -8,7 +8,9 @@ use egui::{
     containers, Color32, ComboBox, Context, DragValue, Frame, Key, KeyboardShortcut, Margin,
     Modifiers, PointerButton, Pos2, Rect, Response, Rounding, Shape, Stroke, Ui, Vec2, Window,
 };
-use epaint::{CircleShape, Shadow};
+use epaint::CircleShape;
+
+use super::helper;
 
 pub fn rect_with_hover<P>(
     rect: Rect,
@@ -25,9 +27,15 @@ where
     let r = ui.allocate_rect(rect, editor_mode_to_sense(editor_mode));
 
     if r.hovered() && !r.dragged() {
-        containers::popup::show_tooltip_for(ui.ctx(), egui::Id::new(id), &rect, |ui| {
-            f(ui);
-        });
+        containers::popup::show_tooltip_for(
+            ui.ctx(),
+            ui.layer_id(),
+            egui::Id::new(id),
+            &rect,
+            |ui| {
+                f(ui);
+            },
+        );
     }
     r
 }
@@ -48,7 +56,7 @@ pub fn properties_window<P>(
                 inner_margin: Margin::same(10f32),
                 outer_margin: Margin::same(0f32),
                 rounding: Rounding::same(10f32),
-                shadow: Shadow::small_dark(),
+                shadow: helper::shadow_small_dark(),
                 fill: ui.visuals().panel_fill,
                 stroke: ui.visuals().window_stroke,
             })
@@ -69,6 +77,8 @@ pub fn properties_window<P>(
     }
 }
 
+/// This function add a horizontal ui section which displays
+/// the given pos and allows for modification
 pub fn pos_drag_value(ui: &mut Ui, pos: &mut (f32, f32)) {
     ui.horizontal(|ui| {
         ui.label("pos x");
@@ -213,12 +223,12 @@ pub fn drag_logic(
         if ctx.input_mut(|i| {
             i.consume_shortcut(&KeyboardShortcut {
                 modifiers: mod_none,
-                key: Key::Delete,
+                logical_key: Key::Delete,
             })
         }) || ctx.input_mut(|i| {
             i.consume_shortcut(&KeyboardShortcut {
                 modifiers: mod_none,
-                key: Key::X,
+                logical_key: Key::X,
             })
         }) {
             delete = true;
@@ -234,7 +244,7 @@ pub fn drag_logic(
             *pos = (pos.0 + delta.x, pos.1 + delta.y);
         }
     }
-    if resp.drag_released_by(PointerButton::Primary)
+    if resp.drag_stopped_by(PointerButton::Primary)
         && resp.interact_pointer_pos().unwrap().x < offset.x
     {
         delete = true;

--- a/src/gui_egui/components/constant.rs
+++ b/src/gui_egui/components/constant.rs
@@ -6,7 +6,9 @@ use crate::gui_egui::component_ui::{
 };
 use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use crate::gui_egui::gui::EguiExtra;
-use egui::{Align2, Area, Color32, DragValue, Order, Pos2, Rect, Response, RichText, Ui, Vec2};
+use egui::{
+    Align2, Area, Color32, DragValue, Order, Pos2, Rect, Response, RichText, TextWrapMode, Ui, Vec2,
+};
 
 #[typetag::serde]
 impl EguiComponent for Constant {
@@ -24,15 +26,17 @@ impl EguiComponent for Constant {
         let mut offset = offset;
         offset.x += self.pos.0 * scale;
         offset.y += self.pos.1 * scale;
-        let area = Area::new(self.id.to_string())
+        let area = Area::new(egui::Id::from(self.id.to_string()))
             .order(Order::Middle)
             .current_pos(offset.to_pos2())
             .movable(false)
             .enabled(true)
             .interactable(false)
             .pivot(Align2::CENTER_CENTER)
+            .constrain(false)
             .show(ui.ctx(), |ui| {
                 ui.set_clip_rect(clip_rect);
+                ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                 match editor_mode {
                     EditorMode::Simulator => ui.label(
                         RichText::new(format!("{}", self.value))

--- a/src/gui_egui/components/probe.rs
+++ b/src/gui_egui/components/probe.rs
@@ -53,7 +53,13 @@ impl EguiComponent for Probe {
                     ),
                     _ => ui.label(RichText::new(text.clone()).size(scale * 12f32).underline()),
                 }
-                .on_hover_text(text);
+                .on_hover_text({
+                    if let SignalValue::Data(v) = value {
+                        format!("{:#010x}\nAs unsigned: {}\nAs signed: {}", v, v, v as i32)
+                    } else {
+                        text
+                    }
+                });
             });
         let rect = area.response.rect;
         let r = rect_with_hover(rect, clip_rect, editor_mode, ui, self.id.clone(), |ui| {

--- a/src/gui_egui/components/probe.rs
+++ b/src/gui_egui/components/probe.rs
@@ -6,7 +6,7 @@ use crate::gui_egui::component_ui::{
 };
 use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use crate::gui_egui::gui::EguiExtra;
-use egui::{Align2, Area, Color32, Order, Pos2, Rect, Response, RichText, Ui, Vec2};
+use egui::{Align2, Area, Color32, Order, Pos2, Rect, Response, RichText, TextWrapMode, Ui, Vec2};
 
 #[typetag::serde]
 impl EguiComponent for Probe {
@@ -29,15 +29,17 @@ impl EguiComponent for Probe {
             Some(s) => s.get_input_value(&input),
             None => SignalValue::Uninitialized,
         };
-        let area = Area::new(self.id.to_string())
+        let area = Area::new(egui::Id::from(self.id.to_string()))
             .order(Order::Middle)
             .current_pos(offset.to_pos2())
             .movable(false)
             .enabled(true)
             .interactable(false)
             .pivot(Align2::CENTER_CENTER)
+            .constrain(false)
             .show(ui.ctx(), |ui| {
                 ui.set_clip_rect(clip_rect);
+                ui.style_mut().wrap_mode = Some(TextWrapMode::Extend);
                 let text = if let SignalValue::Data(v) = value {
                     format!("{:#010x}", v)
                 } else {
@@ -53,22 +55,15 @@ impl EguiComponent for Probe {
                 }
                 .on_hover_text(text);
             });
-
-        let r = rect_with_hover(
-            area.response.rect,
-            clip_rect,
-            editor_mode,
-            ui,
-            self.id.clone(),
-            |ui| {
-                ui.label(format!("Id: {}", self.id.clone()));
-                if let SignalValue::Data(v) = value {
-                    ui.label(format!("{:#010x}", v));
-                } else {
-                    ui.label(format!("{:?}", value));
-                }
-            },
-        );
+        let rect = area.response.rect;
+        let r = rect_with_hover(rect, clip_rect, editor_mode, ui, self.id.clone(), |ui| {
+            ui.label(format!("Id: {}", self.id.clone()));
+            if let SignalValue::Data(v) = value {
+                ui.label(format!("{:#010x}", v));
+            } else {
+                ui.label(format!("{:?}", value));
+            }
+        });
         match editor_mode {
             EditorMode::Simulator => (),
             _ => visualize_ports(ui, self.ports_location(), offset_old, scale, clip_rect),

--- a/src/gui_egui/components/probe_edit.rs
+++ b/src/gui_egui/components/probe_edit.rs
@@ -6,7 +6,7 @@ use crate::gui_egui::component_ui::{
 };
 use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use crate::gui_egui::gui::EguiExtra;
-use egui::{Align2, Area, DragValue, Order, Pos2, Rect, Response, Ui, Vec2};
+use egui::{Align2, Area, DragValue, Order, Pos2, Rect, Response, TextStyle, Ui, Vec2};
 
 #[typetag::serde]
 impl EguiComponent for ProbeEdit {
@@ -25,13 +25,14 @@ impl EguiComponent for ProbeEdit {
         offset.x += self.pos.0 * scale;
         offset.y += self.pos.1 * scale;
         let interact = matches!(editor_mode, EditorMode::Simulator);
-        let area = Area::new(self.id.to_string())
+        let area = Area::new(egui::Id::from(self.id.to_string()))
             .order(Order::Middle)
             .current_pos(offset.to_pos2())
             .movable(false)
             .enabled(true)
             .interactable(interact)
             .pivot(Align2::CENTER_CENTER)
+            .constrain(false)
             .show(ui.ctx(), |ui| {
                 ui.set_clip_rect(clip_rect);
                 let hst = self.edit_history.clone();
@@ -41,6 +42,11 @@ impl EguiComponent for ProbeEdit {
                     SignalValue::Data(d) => {
                         let mut val = d;
                         // todo: Somehow make this scale...
+                        ui.style_mut() // manage to change the font size but not the background
+                            .text_styles
+                            .get_mut(&TextStyle::Button)
+                            .unwrap()
+                            .size = scale * 12f32;
                         let r = ui.add(DragValue::new(&mut val));
                         *self.edit_history.write().unwrap().last_mut().unwrap() = TextSignal {
                             text: format!("{}", val),

--- a/src/gui_egui/components/wire.rs
+++ b/src/gui_egui/components/wire.rs
@@ -5,12 +5,11 @@ use crate::gui_egui::component_ui::{
 };
 use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions, SnapPriority};
 use crate::gui_egui::gui::EguiExtra;
-use crate::gui_egui::helper::offset_helper;
+use crate::gui_egui::helper::{offset_helper, shadow_small_dark};
 use egui::{
     Color32, DragValue, Frame, Key, KeyboardShortcut, Margin, Modifiers, PointerButton, Pos2, Rect,
     Response, Rounding, Shape, Stroke, Ui, Vec2, Window,
 };
-use epaint::Shadow;
 
 #[typetag::serde]
 impl EguiComponent for Wire {
@@ -119,7 +118,7 @@ impl EguiComponent for Wire {
                             mac_cmd: false,
                             command: false,
                         },
-                        key: Key::Delete,
+                        logical_key: Key::Delete,
                     })
                 }) || ui.ctx().input_mut(|i| {
                     i.consume_shortcut(&KeyboardShortcut {
@@ -130,7 +129,7 @@ impl EguiComponent for Wire {
                             mac_cmd: false,
                             command: false,
                         },
-                        key: Key::X,
+                        logical_key: Key::X,
                     })
                 }) {
                     delete = true;
@@ -139,7 +138,7 @@ impl EguiComponent for Wire {
                 self.pos[i] = (self.pos[i].0 + delta.x, self.pos[i].1 + delta.y);
                 self.pos[i + 1] = (self.pos[i + 1].0 + delta.x, self.pos[i + 1].1 + delta.y);
             }
-            if resp.drag_released_by(PointerButton::Primary)
+            if resp.drag_stopped_by(PointerButton::Primary)
                 && resp.interact_pointer_pos().unwrap().x < offset.x
             {
                 delete = true;
@@ -153,7 +152,7 @@ impl EguiComponent for Wire {
                     inner_margin: Margin::same(10f32),
                     outer_margin: Margin::same(0f32),
                     rounding: Rounding::same(10f32),
-                    shadow: Shadow::small_dark(),
+                    shadow: shadow_small_dark(),
                     fill: ui.visuals().panel_fill,
                     stroke: ui.visuals().window_stroke,
                 })

--- a/src/gui_egui/components/wire.rs
+++ b/src/gui_egui/components/wire.rs
@@ -10,7 +10,6 @@ use egui::{
     Color32, DragValue, Frame, Key, KeyboardShortcut, Margin, Modifiers, PointerButton, Pos2, Rect,
     Response, Rounding, Shape, Stroke, Ui, Vec2, Window,
 };
-use epaint::Shadow;
 use log::trace;
 
 #[typetag::serde]

--- a/src/gui_egui/editor.rs
+++ b/src/gui_egui/editor.rs
@@ -392,9 +392,9 @@ impl Editor {
         }
         if central_panel.response.hovered() {
             ctx.input_mut(|i| {
-                if i.scroll_delta.y > 0f32 {
+                if i.raw_scroll_delta.y > 0f32 {
                     keymap::view_zoom_in_fn(gui);
-                } else if i.scroll_delta.y < 0f32 {
+                } else if i.raw_scroll_delta.y < 0f32 {
                     keymap::view_zoom_out_fn(gui);
                 }
             });

--- a/src/gui_egui/gui.rs
+++ b/src/gui_egui/gui.rs
@@ -103,7 +103,7 @@ impl eframe::App for Gui {
             self.top_bar(ctx);
             if self.simulator.is_some() {
                 // self.side_panel(ctx);
-                if self.simulator.as_ref().unwrap().running {
+                if self.simulator.as_ref().unwrap().is_running() {
                     self.simulator.as_mut().unwrap().run();
 
                     // This makes the ui run agin as to not stop the simulation

--- a/src/gui_egui/gui.rs
+++ b/src/gui_egui/gui.rs
@@ -26,6 +26,7 @@ pub struct Gui {
     pub clip_rect: Rect,
     pub shortcuts: Shortcuts,
     pub pause: bool,
+    pub step_amount: usize, //TODO change this to be a menu struct, and maybe move pause and other here
     pub editor: Option<Editor>,
     pub editor_use: bool,
     pub contexts: HashMap<crate::common::Id, EguiExtra>,
@@ -57,6 +58,7 @@ pub fn gui(cs: ComponentStore, path: &PathBuf, library: Library) -> Result<(), e
         clip_rect: Rect::NOTHING,
         shortcuts: Shortcuts::new(),
         pause: true,
+        step_amount: 10,
         editor: None,
         editor_use: false,
         contexts,

--- a/src/gui_egui/helper.rs
+++ b/src/gui_egui/helper.rs
@@ -1,6 +1,7 @@
 use crate::common::{Components, Ports};
 use crate::gui_egui::editor::{EditorMode, SnapPriority};
-use egui::{Pos2, Rect, Sense, Vec2};
+use egui::{Color32, Pos2, Rect, Sense, Vec2};
+use epaint::Shadow;
 
 pub fn offset_reverse_helper_pos2(xy: Pos2, scale: f32, offset: Vec2) -> Pos2 {
     egui::Pos2 {
@@ -104,5 +105,14 @@ pub fn editor_mode_to_sense(editor_mode: EditorMode) -> Sense {
             drag: true,
             focusable: true,
         },
+    }
+}
+
+pub fn shadow_small_dark() -> Shadow {
+    Shadow {
+        offset: Vec2 { x: 5.0, y: 5.0 },
+        blur: 5.0,
+        spread: 0.0,
+        color: Color32::BLACK,
     }
 }

--- a/src/gui_egui/keymap.rs
+++ b/src/gui_egui/keymap.rs
@@ -67,15 +67,15 @@ impl Shortcuts {
         Shortcuts {
             file_new: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::N,
+                logical_key: Key::N,
             },
             file_open: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::O,
+                logical_key: Key::O,
             },
             file_save: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::S,
+                logical_key: Key::S,
             },
             file_save_as: KeyboardShortcut {
                 modifiers: Modifiers {
@@ -85,43 +85,43 @@ impl Shortcuts {
                     mac_cmd: false,
                     command: false,
                 },
-                key: Key::S,
+                logical_key: Key::S,
             },
             file_editor_toggle: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::E,
+                logical_key: Key::E,
             },
             file_preferences: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::P,
+                logical_key: Key::P,
             },
             file_quit: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::Q,
+                logical_key: Key::Q,
             },
             edit_cut: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::X,
+                logical_key: Key::X,
             },
             edit_copy: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::C,
+                logical_key: Key::C,
             },
             edit_paste: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::P,
+                logical_key: Key::P,
             },
             view_zoom_in: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::PlusEquals,
+                logical_key: Key::Plus,
             },
             view_zoom_out: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::Minus,
+                logical_key: Key::Minus,
             },
             view_grid_toggle: KeyboardShortcut {
                 modifiers: ctrl,
-                key: Key::G,
+                logical_key: Key::G,
             },
             view_grid_snap_toggle: KeyboardShortcut {
                 modifiers: Modifiers {
@@ -131,19 +131,19 @@ impl Shortcuts {
                     mac_cmd: false,
                     command: false,
                 },
-                key: Key::G,
+                logical_key: Key::G,
             },
             control_play: KeyboardShortcut {
                 modifiers: none,
-                key: Key::F6,
+                logical_key: Key::F6,
             },
             control_play_toggle: KeyboardShortcut {
                 modifiers: none,
-                key: Key::F5,
+                logical_key: Key::F5,
             },
             control_pause: KeyboardShortcut {
                 modifiers: shift,
-                key: Key::F5,
+                logical_key: Key::F5,
             },
             control_reset: KeyboardShortcut {
                 modifiers: Modifiers {
@@ -153,23 +153,23 @@ impl Shortcuts {
                     mac_cmd: false,
                     command: false,
                 },
-                key: Key::F5,
+                logical_key: Key::F5,
             },
             control_step_forward: KeyboardShortcut {
                 modifiers: none,
-                key: Key::F10,
+                logical_key: Key::F10,
             },
             control_step_back: KeyboardShortcut {
                 modifiers: shift,
-                key: Key::F10,
+                logical_key: Key::F10,
             },
             editor_wire_mode: KeyboardShortcut {
                 modifiers: none,
-                key: Key::W,
+                logical_key: Key::W,
             },
             editor_escape: KeyboardShortcut {
                 modifiers: none,
-                key: Key::Escape,
+                logical_key: Key::Escape,
             },
         }
     }

--- a/src/gui_egui/keymap.rs
+++ b/src/gui_egui/keymap.rs
@@ -399,7 +399,7 @@ pub fn control_play_fn(gui: &mut Gui) {
 pub fn control_pause_fn(gui: &mut Gui) {
     if !gui.editor_use {
         gui.pause = true;
-        gui.simulator.as_mut().unwrap().stop();
+        let _ = gui.simulator.as_mut().unwrap().stop();
     }
 }
 pub fn control_reset_fn(gui: &mut Gui) {

--- a/src/gui_egui/keymap.rs
+++ b/src/gui_egui/keymap.rs
@@ -386,7 +386,7 @@ pub fn control_play_toggle_fn(gui: &mut Gui) {
 pub fn control_play_fn(gui: &mut Gui) {
     if !gui.editor_use {
         gui.pause = false;
-        gui.simulator.as_mut().unwrap().running = true;
+        let _ = gui.simulator.as_mut().unwrap().set_running();
         //gui.simulator.as_mut().unwrap().run();
         //gui.pause = true;
     }
@@ -399,7 +399,7 @@ pub fn control_play_fn(gui: &mut Gui) {
 pub fn control_pause_fn(gui: &mut Gui) {
     if !gui.editor_use {
         gui.pause = true;
-        gui.simulator.as_mut().unwrap().running = false;
+        gui.simulator.as_mut().unwrap().stop();
     }
 }
 pub fn control_reset_fn(gui: &mut Gui) {

--- a/src/gui_egui/library.rs
+++ b/src/gui_egui/library.rs
@@ -5,7 +5,9 @@ use crate::gui_egui::{
     editor_wire_mode::get_grid_snap,
     helper::{id_ports_of_all_components, offset_reverse_helper_pos2, unique_component_name},
 };
-use egui::{Context, CursorIcon, LayerId, PointerButton, Pos2, Rect, Response, Ui, Vec2};
+use egui::{
+    Context, CursorIcon, LayerId, PointerButton, Pos2, Rect, Response, Ui, UiStackInfo, Vec2,
+};
 use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
 pub struct InputMode {
@@ -41,6 +43,7 @@ pub fn input_mode(ctx: &Context, e: &mut Editor, cpr: Response, layer_id: Option
         "input".into(),
         clip_rect,
         Rect::EVERYTHING,
+        UiStackInfo::new(egui::UiKind::Frame),
     );
     let pos = if e.grid.enable && e.grid.snap_enable {
         match get_grid_snap(

--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -42,7 +42,7 @@ impl Menu {
             if ui.button("⟳").clicked() {
                 // TODO dont have simulator here add keymap
                 if let Some(s) = gui.simulator.as_mut() {
-                    s.set_step_to(s.cycle + gui.step_amount);
+                    let _ = s.set_step_to(s.cycle + gui.step_amount);
                 }
             }
 

--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -66,13 +66,13 @@ impl Menu {
                 });
                 ui.horizontal(|ui| {
                     ui.label("Grid Size:");
-                    ui.add(DragValue::new(&mut grid_size).clamp_range(5f32..=10000f32));
+                    ui.add(DragValue::new(&mut grid_size).range(5f32..=10000f32));
                 });
                 ui.horizontal(|ui| {
                     ui.label("Grid Opacity:");
                     ui.add(
                         DragValue::new(&mut grid_opacity)
-                            .clamp_range(0f32..=1f32)
+                            .range(0f32..=1f32)
                             .speed(0.02f32),
                     );
                 });
@@ -82,7 +82,7 @@ impl Menu {
                 });
                 ui.horizontal(|ui| {
                     ui.label("Grid Snap Distance:");
-                    ui.add(DragValue::new(&mut grid_snap_distance).clamp_range(0f32..=100f32));
+                    ui.add(DragValue::new(&mut grid_snap_distance).range(0f32..=100f32));
                 });
             });
             editor(gui).scale = scale;

--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -36,6 +36,18 @@ impl Menu {
             if ui.button("⏸").clicked() {
                 keymap::control_pause_fn(gui);
             }
+            ui.separator();
+
+            ui.add(DragValue::new(&mut gui.step_amount).prefix("Step: "));
+            if ui.button("⟳").clicked() {
+                // TODO dont have simulator here add keymap
+                if let Some(s) = gui.simulator.as_mut() {
+                    s.set_step_to(s.cycle + gui.step_amount);
+                }
+            }
+
+            ui.separator();
+
             if let Some(s) = gui.simulator.as_ref() {
                 ui.label(format!("Cycle: {}", s.cycle));
 

--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -37,7 +37,23 @@ impl Menu {
                 keymap::control_pause_fn(gui);
             }
             if let Some(s) = gui.simulator.as_ref() {
-                ui.label(format!("Cycle #{}", s.cycle));
+                ui.label(format!("Cycle: {}", s.cycle));
+
+                // This displays the current state of the simulation,
+                // if hovered displays the component condition vector
+                let r = ui.label(format!("State: {:?}", s.get_state()));
+
+                // if there are some components  that reported a condition show it when
+                // state is hovered over
+                if let Some(cond_vec) = s.get_component_condition() {
+                    r.on_hover_text(
+                        cond_vec // format all id condition pairs and sum them to a string
+                            .iter()
+                            .fold(String::from("Reported conditions"), |acc, id_cond| {
+                                acc + &format!("\nID: {}, {:?}", id_cond.0, id_cond.1)
+                            }),
+                    );
+                }
             }
         });
     }

--- a/src/gui_vizia/gui.rs
+++ b/src/gui_vizia/gui.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{ComponentStore, Simulator},
+    common::{ComponentStore, RunningState, Simulator},
     gui_vizia::{grid::Grid, keymap::init_keymap, menu::Menu, transport::Transport},
 };
 use rfd::FileDialog;
@@ -70,15 +70,19 @@ impl Model for GuiData {
                 self.simulator.reset();
             }
             GuiEvent::Play => {
-                self.simulator.running = true;
+                self.simulator.running_state = RunningState::Running;
                 self.simulator.clock();
             }
             GuiEvent::Pause => {
-                self.simulator.running = false;
+                self.simulator.running_state = RunningState::Halt;
             }
             GuiEvent::PlayToggle => {
-                self.simulator.running = !self.simulator.running;
-                if self.simulator.running {
+                if self.simulator.running_state == RunningState::Running {
+                    self.simulator.running_state = RunningState::Halt;
+                } else {
+                    self.simulator.running_state = RunningState::Running;
+                }
+                if self.simulator.running_state == RunningState::Running {
                     self.simulator.clock();
                 }
             }
@@ -154,7 +158,7 @@ pub fn gui(cs: ComponentStore, path: &PathBuf) {
 
             //let simulator = GuiData::simulator.get(cx);
             let simulator = GuiData::simulator.view(cx.data().unwrap()).unwrap();
-            if simulator.running {
+            if simulator.running_state == RunningState::Running {
                 trace!("send clock event");
                 cx.emit(GuiEvent::Clock);
             };

--- a/src/gui_vizia/transport.rs
+++ b/src/gui_vizia/transport.rs
@@ -1,4 +1,4 @@
-use crate::common::Simulator;
+use crate::common::{RunningState, Simulator};
 use crate::gui_vizia::{GuiData, GuiEvent};
 use vizia::{icons, prelude::*};
 pub(crate) struct Transport {}
@@ -78,13 +78,15 @@ impl Transport {
                     |cx| {
                         Label::new(
                             cx,
-                            GuiData::simulator.then(Simulator::running).map(|running| {
-                                if *running {
-                                    icons::ICON_PLAYER_PLAY_FILLED
-                                } else {
-                                    icons::ICON_PLAYER_PLAY
-                                }
-                            }),
+                            GuiData::simulator
+                                .then(Simulator::running_state)
+                                .map(|running| {
+                                    if *running == RunningState::Running {
+                                        icons::ICON_PLAYER_PLAY_FILLED
+                                    } else {
+                                        icons::ICON_PLAYER_PLAY
+                                    }
+                                }),
                         )
                         .on_press(|cx| cx.emit(GuiEvent::Play))
                         .class("icon")
@@ -107,13 +109,15 @@ impl Transport {
                     |cx| {
                         Label::new(
                             cx,
-                            GuiData::simulator.then(Simulator::running).map(|running| {
-                                if *running {
-                                    icons::ICON_PLAYER_PAUSE
-                                } else {
-                                    icons::ICON_PLAYER_PAUSE_FILLED
-                                }
-                            }),
+                            GuiData::simulator
+                                .then(Simulator::running_state)
+                                .map(|running| {
+                                    if *running == RunningState::Running {
+                                        icons::ICON_PLAYER_PAUSE
+                                    } else {
+                                        icons::ICON_PLAYER_PAUSE_FILLED
+                                    }
+                                }),
                         )
                         .on_press(|cx| cx.emit(GuiEvent::Pause))
                         .class("icon")

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -293,7 +293,7 @@ impl Simulator {
     pub fn run(&mut self) {
         use std::time::Instant;
         let now = Instant::now();
-        let mut i = 0;
+        let mut i: u32 = 0; // used to quickly and inaccurately test performance
         while now.elapsed().as_millis() < 1000 / 30 {
             //30Hz
             i += 1;
@@ -302,12 +302,17 @@ impl Simulator {
                 RunningState::StepTo(target_cycle) => {
                     if self.cycle < target_cycle {
                         self.clock();
+                    } else {
+                        self.running_state = RunningState::Stopped;
+                        break;
                     }
                 }
-                _ => {}
+                _ => {
+                    break;
+                }
             }
         }
-        debug!("clock per sec {}", i * 30)
+        trace!("clock per run {}", i)
     }
 
     pub fn run_threaded(&mut self) {}
@@ -366,6 +371,16 @@ impl Simulator {
     pub fn set_running(&mut self) -> Result<(), ()> {
         if self.running_state != RunningState::Err {
             self.running_state = RunningState::Running;
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    // TODO return error if simulator running state is Err
+    pub fn set_step_to(&mut self, target_cycle: usize) -> Result<(), ()> {
+        if self.running_state != RunningState::Err {
+            self.running_state = RunningState::StepTo(target_cycle);
             Ok(())
         } else {
             Err(())

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -452,7 +452,7 @@ impl Simulator {
         self.history = vec![];
         self.cycle = 0;
         self.running_state = RunningState::Stopped;
-        self.stop();
+        let _ = self.stop();
 
         self.sim_state.iter_mut().for_each(|val| *val = 0.into());
 


### PR DESCRIPTION
# Egui were updated to 0.28.0
egui were updated to 0.28.0, required moving where clock() were called
as the preprocessing previous used have been deprecated. other changes where minor

# Simulator State

## Overview
State were added to simulator, allowing to set state to StepTo making the simulator automatically stop when a cycle is reached.
It also track if an halt, assert or error occurred during clocking the simulator.

compoennt codition vector were added allowing to se what may have caused a change in running state

## GUI
Both simulator state and Componente condition vector were incopretaed into the ui
![image](https://github.com/user-attachments/assets/085d7563-5db0-4031-acb0-95c8dec09b79)

![image](https://github.com/user-attachments/assets/7a113347-c550-4f73-be62-23247015aa98)



## Changes
Two simulator fields were added and one changed
- running -> running_state
    - Used to track if its running, halted, steping to a cycle or a Error ocured
- component_condition
    - Used to keep track of what condition where reported during current cycle
- halt_on_warnings
    - If simulation should halt if a components reports a warning
    
    
Two struct were created, RunningState and SimulatorError. RunningState enum can be running, stepping, stop, halt, assert or error. and  SimulatorError enum is currently not fully implemented but is returned if clock or other function tries to run when state is error.

The Clock function were changed to update state and track component condition. This was done by adding all conditions reported to the vector and get the max Condition of the said vector, using derived compare on condition. The max condition is used to update state to an appropriate value.

some changes in gui were made to add the buttons and labels winch show state and reported conditions.

# Misc
- Default fern setup was changed to stop reporting when a redraw happens.
- Updated tool-tip for probe