### PR TITLE
add RISC-V to build tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,10 @@ jobs:
           args: --no-default-features --features gui-egui
       - name: Run tests
         run: cargo test --workspace --no-default-features --features components --verbose
+      - name: Build RISC-V
+        run: | 
+          cd riscv
+          cargo build --example riscv --verbose
   rustfmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As mentioned in #85 , it makes sense to also make sure the RISC-V model builds in CI. 