### PR TITLE
Mips UI fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 members = [ "mips-lib", "riscv"]
 
 [dependencies]
-MIPS_disassembly = "0.1.2"
+MIPS_disassembly = "=0.1.3"
 anyhow = "1.0.72"
 clap = { version = "4.3.15", features = ["derive"] }
 elf = "0.7.4"

--- a/mips-lib/mips_single_cycle.json
+++ b/mips-lib/mips_single_cycle.json
@@ -196,8 +196,8 @@
       "type": "PhysicalMem",
       "id": "phys_mem",
       "pos": [
-        0.0,
-        0.0
+        425.0,
+        575.0
       ]
     },
     {

--- a/mips-lib/src/gui_egui/mips_mem_view_window.rs
+++ b/mips-lib/src/gui_egui/mips_mem_view_window.rs
@@ -234,6 +234,10 @@ impl MemViewWindow {
 
                     // add submenu with a button for each symbol, which sets self.go_to_address
                     ui.menu_button("symbol", |ui| {
+                        let because_lifetimes_sad = mem.get_symbol_table();
+                        let mut sections = because_lifetimes_sad.iter().collect::<Vec<_>>();
+                        sections.sort_by(|a, b| a.0.partial_cmp(b.0).unwrap());
+
                         ScrollArea::vertical().show(ui, |ui| {
                             let because_lifetimes_sad = mem.get_symbol_table();
                             let mut symbols = because_lifetimes_sad.iter().collect::<Vec<_>>();
@@ -253,13 +257,26 @@ impl MemViewWindow {
                         let mut sections = because_lifetimes_sad.iter().collect::<Vec<_>>();
                         sections.sort_by(|a, b| a.0.partial_cmp(b.0).unwrap());
 
-                        for (key, v) in sections {
-                            if ui.button(format!("{} {:#0x}", v, key)).clicked() {
-                                self.go_to_address = set_address(&self.go_type, *key);
-                                ui.close_menu();
-                                close_menu = true;
+                        // for (key, v) in sections {
+                        //     if ui.button(format!("{} {:#0x}", v, key)).clicked() {
+                        //         self.go_to_address = set_address(&self.go_type, *key);
+                        //         ui.close_menu();
+                        //         close_menu = true;
+                        //     }
+                        // }
+                        ScrollArea::vertical().show(ui, |ui| {
+                            let because_lifetimes_sad = mem.get_section_table();
+                            let mut section = because_lifetimes_sad.iter().collect::<Vec<_>>();
+                            section.sort_by(|a, b| a.0.partial_cmp(b.0).unwrap());
+
+                            for (key, v) in section {
+                                if ui.button(format!("{} {:#0x}", v, key)).clicked() {
+                                    self.go_to_address = set_address(&self.go_type, *key);
+                                    ui.close_menu();
+                                    close_menu = true;
+                                }
                             }
-                        }
+                        });
                     });
 
                     // Does any PC pointer exists, make them visible in this menu for quick access
@@ -484,7 +501,7 @@ impl MemViewWindow {
             }
             DataFormat::HexAndMips => {
                 format!(
-                    "{:#010x} {:015}",
+                    "{:#010x}   {:015}",
                     data_u32,
                     MIPS_disassembly::get_disassembly_adv(
                         data_u32,


### PR DESCRIPTION
Adds scrolling to sections.

Sets MIPS_disassembly to a stable version.

Moves PhysicalMem away from top left as a quick fix to resolve a bug where you cnat click on thing on the top bar due to a component being underneath.