### PR TITLE
enable LTO, fixes components being incorrectly optimized out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ debug = 1 # faster build, still allows for stack back trace
 opt-level = 3
 
 [profile.release]
+lto = true # equivalent to fat
 incremental = true
 debug = 1          # faster build, still allows for stack back trace
 


### PR DESCRIPTION
On some setups, the imported components are optimized out since they're only instantiated dynamically, which causes a runtime error. This seems to fix that.