### PR TITLE
Fixed problem with setting "Step:" to high values

### DIFF
--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -37,8 +37,12 @@ impl Menu {
             }
             ui.separator();
 
-            ui.add(DragValue::new(&mut gui.step_amount).prefix("Step: "));
-            if ui.button("⟳").clicked() {
+            ui.add(
+                DragValue::new(&mut gui.step_amount)
+                    .prefix("Step: ")
+                    .range(0..=u32::MAX),
+            );
+            if ui.button("⟳").clicked() {            if ui.button("⟳").clicked() {
                 // TODO dont have simulator here add keymap
                 if let Some(s) = gui.simulator.as_mut() {
                     let _ = s.set_step_to(s.cycle + gui.step_amount);

--- a/src/gui_egui/menu.rs
+++ b/src/gui_egui/menu.rs
@@ -42,7 +42,7 @@ impl Menu {
                     .prefix("Step: ")
                     .range(0..=u32::MAX),
             );
-            if ui.button("⟳").clicked() {            if ui.button("⟳").clicked() {
+            if ui.button("⟳").clicked() {
                 // TODO dont have simulator here add keymap
                 if let Some(s) = gui.simulator.as_mut() {
                     let _ = s.set_step_to(s.cycle + gui.step_amount);


### PR DESCRIPTION
Several problems and weird behaviours arise if step_count is given value much larger than 2^32, this also includes overflow. The artificial border of 2^32 prevents this while still being significantly larger than necessary for regular use