### PR TITLE
unpin vizia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ typetag = "0.2.10"
 
 [dependencies.vizia]
 git = "https://github.com/vizia/vizia.git"
-rev = "7093bfd518c4bee5544a75c2ffc92dfe4f817bc0"
+#rev = "7093bfd518c4bee5544a75c2ffc92dfe4f817bc0"
 #path = "../vizia"
 optional = true
 


### PR DESCRIPTION
the vizia rev that we pin against has a git dependency to a branch of `morphorm` which no longer exists. as a result, cargo fails to resolve dependencies, and syncrim does not build at all. this unpins the vizia dependency.