### PR TITLE
Editor fixes and basic editor popup helper func

### DIFF
--- a/mips-lib/src/gui_egui/components/mips_alu_forward.rs
+++ b/mips-lib/src/gui_egui/components/mips_alu_forward.rs
@@ -6,7 +6,7 @@ use egui::{pos2, Rect, Response, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 #[typetag::serde]
 impl EguiComponent for AluForward {
@@ -33,11 +33,11 @@ impl EguiComponent for AluForward {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -45,11 +45,8 @@ impl EguiComponent for AluForward {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_alu_forward.rs
+++ b/mips-lib/src/gui_egui/components/mips_alu_forward.rs
@@ -37,16 +37,19 @@ impl EguiComponent for AluForward {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_branch_logic.rs
+++ b/mips-lib/src/gui_egui/components/mips_branch_logic.rs
@@ -3,7 +3,7 @@ use egui::{Rect, Response, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 #[typetag::serde]
 impl EguiComponent for BranchLogic {
@@ -30,11 +30,11 @@ impl EguiComponent for BranchLogic {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -42,11 +42,8 @@ impl EguiComponent for BranchLogic {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_branch_logic.rs
+++ b/mips-lib/src/gui_egui/components/mips_branch_logic.rs
@@ -34,16 +34,19 @@ impl EguiComponent for BranchLogic {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_control_unit.rs
+++ b/mips-lib/src/gui_egui/components/mips_control_unit.rs
@@ -44,16 +44,19 @@ impl EguiComponent for ControlUnit {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_control_unit.rs
+++ b/mips-lib/src/gui_egui/components/mips_control_unit.rs
@@ -3,7 +3,7 @@ use egui::{pos2, Pos2, Rect, Response, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 const WIDTH: f32 = 400.0;
 const HEIGHT: f32 = 15.0;
@@ -40,11 +40,11 @@ impl EguiComponent for ControlUnit {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -52,11 +52,8 @@ impl EguiComponent for ControlUnit {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_data_forward.rs
+++ b/mips-lib/src/gui_egui/components/mips_data_forward.rs
@@ -6,7 +6,7 @@ use egui::{pos2, Rect, Response, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 #[typetag::serde]
 impl EguiComponent for DataForward {
@@ -33,11 +33,11 @@ impl EguiComponent for DataForward {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -45,11 +45,8 @@ impl EguiComponent for DataForward {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_data_forward.rs
+++ b/mips-lib/src/gui_egui/components/mips_data_forward.rs
@@ -37,15 +37,18 @@ impl EguiComponent for DataForward {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
         basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 

--- a/mips-lib/src/gui_egui/components/mips_dm.rs
+++ b/mips-lib/src/gui_egui/components/mips_dm.rs
@@ -3,7 +3,7 @@ use egui::{pos2, Pos2, Rect, Response, RichText, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 const WIDTH: f32 = 120.0;
 const HEIGHT: f32 = 55.0;
@@ -104,11 +104,11 @@ impl EguiComponent for DataMem {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -116,11 +116,8 @@ impl EguiComponent for DataMem {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_dm.rs
+++ b/mips-lib/src/gui_egui/components/mips_dm.rs
@@ -108,16 +108,19 @@ impl EguiComponent for DataMem {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_im.rs
+++ b/mips-lib/src/gui_egui/components/mips_im.rs
@@ -13,6 +13,7 @@ use syncrim::common::{EguiComponent, Id, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
 use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::basic_editor_popup;
 
 const WIDTH: f32 = 120.0;
 const HEIGHT: f32 = 55.0;
@@ -112,11 +113,11 @@ impl EguiComponent for InstrMem {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -124,11 +125,9 @@ impl EguiComponent for InstrMem {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_im.rs
+++ b/mips-lib/src/gui_egui/components/mips_im.rs
@@ -117,17 +117,19 @@ impl EguiComponent for InstrMem {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
-
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_instruction_splitter.rs
+++ b/mips-lib/src/gui_egui/components/mips_instruction_splitter.rs
@@ -48,17 +48,19 @@ impl EguiComponent for InstrSplit {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-                let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
-
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_instruction_splitter.rs
+++ b/mips-lib/src/gui_egui/components/mips_instruction_splitter.rs
@@ -7,7 +7,7 @@ use egui::{pos2, Pos2, Rect, Response, RichText, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 const WIDTH: f32 = 50.0;
 const HEIGHT: f32 = 200.0;
@@ -44,11 +44,11 @@ impl EguiComponent for InstrSplit {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+                let res = self.render(
             ui,
             context,
             simulator,
@@ -56,11 +56,9 @@ impl EguiComponent for InstrSplit {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_jump_merge.rs
+++ b/mips-lib/src/gui_egui/components/mips_jump_merge.rs
@@ -34,17 +34,19 @@ impl EguiComponent for JumpMerge {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
-
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_jump_merge.rs
+++ b/mips-lib/src/gui_egui/components/mips_jump_merge.rs
@@ -3,7 +3,7 @@ use egui::{Rect, Response, RichText, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 #[typetag::serde]
 impl EguiComponent for JumpMerge {
@@ -30,11 +30,11 @@ impl EguiComponent for JumpMerge {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -42,11 +42,9 @@ impl EguiComponent for JumpMerge {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/mips_reg_file.rs
+++ b/mips-lib/src/gui_egui/components/mips_reg_file.rs
@@ -126,17 +126,19 @@ impl EguiComponent for RegFile {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
-
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn get_input_location(&self, id: Input) -> Option<(f32, f32)> {

--- a/mips-lib/src/gui_egui/components/mips_reg_file.rs
+++ b/mips-lib/src/gui_egui/components/mips_reg_file.rs
@@ -3,7 +3,7 @@ use egui::{vec2, Color32, ComboBox, Pos2, Rect, Response, RichText, ScrollArea, 
 use syncrim::common::{EguiComponent, Input, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 use syncrim::signal::Id;
 
 const REG_NAMES: [&str; 32] = [
@@ -122,11 +122,11 @@ impl EguiComponent for RegFile {
         offset: Vec2,
         scale: f32,
         clip_rect: Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -134,11 +134,9 @@ impl EguiComponent for RegFile {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+
     }
 
     fn get_input_location(&self, id: Input) -> Option<(f32, f32)> {

--- a/mips-lib/src/gui_egui/components/physical_mem.rs
+++ b/mips-lib/src/gui_egui/components/physical_mem.rs
@@ -34,16 +34,19 @@ impl EguiComponent for PhysicalMem {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/physical_mem.rs
+++ b/mips-lib/src/gui_egui/components/physical_mem.rs
@@ -3,7 +3,7 @@ use egui::{Rect, Response, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Ports, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 #[typetag::serde]
 impl EguiComponent for PhysicalMem {
@@ -30,11 +30,11 @@ impl EguiComponent for PhysicalMem {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -42,11 +42,8 @@ impl EguiComponent for PhysicalMem {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/sz_extend.rs
+++ b/mips-lib/src/gui_egui/components/sz_extend.rs
@@ -59,17 +59,19 @@ impl EguiComponent for SignZeroExtend {
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        let res = self.render(
-            ui,
-            context,
-            simulator,
-            offset,
-            scale,
-            clip_rect,
-            editor_mode,
-        ).unwrap().remove(0);
-        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
-
+        let res = self
+            .render(
+                ui,
+                context,
+                simulator,
+                offset,
+                scale,
+                clip_rect,
+                editor_mode,
+            )
+            .unwrap()
+            .remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_| {})
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/mips-lib/src/gui_egui/components/sz_extend.rs
+++ b/mips-lib/src/gui_egui/components/sz_extend.rs
@@ -3,7 +3,7 @@ use egui::{pos2, Pos2, Rect, Response, RichText, Ui, Vec2};
 use syncrim::common::{EguiComponent, Id, Input, Ports, SignalValue, Simulator};
 use syncrim::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions};
 use syncrim::gui_egui::gui::EguiExtra;
-use syncrim::gui_egui::helper::basic_component_gui;
+use syncrim::gui_egui::helper::{basic_component_gui, basic_editor_popup};
 
 const WIDTH: f32 = 105.0;
 const HEIGHT: f32 = 30.0;
@@ -55,11 +55,11 @@ impl EguiComponent for SignZeroExtend {
         offset: egui::Vec2,
         scale: f32,
         clip_rect: egui::Rect,
-        _id_ports: &[(Id, Ports)],
+        id_ports: &[(Id, Ports)],
         _grid: &GridOptions,
         editor_mode: EditorMode,
     ) -> EditorRenderReturn {
-        self.render(
+        let res = self.render(
             ui,
             context,
             simulator,
@@ -67,11 +67,9 @@ impl EguiComponent for SignZeroExtend {
             scale,
             clip_rect,
             editor_mode,
-        );
-        EditorRenderReturn {
-            delete: false,
-            resp: None,
-        }
+        ).unwrap().remove(0);
+        basic_editor_popup(self, ui, context, id_ports, res, |_|{})
+
     }
 
     fn set_pos(&mut self, pos: (f32, f32)) {

--- a/src/gui_egui/components/wire.rs
+++ b/src/gui_egui/components/wire.rs
@@ -5,9 +5,9 @@ use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, GridOptions, SnapP
 use crate::gui_egui::gui::EguiExtra;
 use crate::gui_egui::helper::{basic_on_hover, offset_helper, shadow_small_dark};
 use egui::{
-    Color32, CornerRadius, DragValue, Frame, Key, KeyboardShortcut, Margin, Modifiers,
-    PointerButton, Pos2, Rect, Response, Sense, Shape, Stroke, StrokeKind, Ui, UiBuilder, Vec2,
-    Window,
+    Align2, Area, Color32, CornerRadius, DragValue, Frame, Key, KeyboardShortcut, Margin,
+    Modifiers, Order, PointerButton, Pos2, Rect, Response, Sense, Shape, Stroke, StrokeKind, Ui,
+    Vec2, Window,
 };
 
 /// if the mouse cursor is less than this distance in points away from the wire display tooltip
@@ -99,14 +99,22 @@ impl EguiComponent for Wire {
             #[allow(clippy::single_match)]
             match editor_mode {
                 EditorMode::Default => {
-                    // why the fuck do i need this much code just to make sure its rendered at the correct layer
-                    let resp = ui
-                        .allocate_new_ui(
-                            UiBuilder::new().layer_id(ui.layer_id()).max_rect(rect),
-                            |ui| ui.allocate_exact_size(rect.size(), Sense::all()),
-                        )
-                        .inner
-                        .1;
+                    // why the fuck do i need this much code just to make sure its rendered at the correct layer (Middle)
+                    // instead of background, that current ui is at
+                    let resp = {
+                        Area::new(format!("{}{:#?}", self.id, rect).into())
+                            .order(Order::Middle)
+                            .sense(Sense::all())
+                            .current_pos(rect.center())
+                            .movable(false)
+                            .enabled(true)
+                            .pivot(Align2::CENTER_CENTER)
+                            .constrain(false)
+                            .show(ui.ctx(), |ui: &mut Ui| {
+                                ui.set_min_size(rect.size());
+                            })
+                    }
+                    .response;
 
                     // log::debug!("{:?}", resp);
                     if resp.contains_pointer() {

--- a/src/gui_egui/helper.rs
+++ b/src/gui_egui/helper.rs
@@ -4,7 +4,7 @@ use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, SnapPriority};
 use crate::gui_egui::EguiExtra;
 use egui::{
     Align2, Area, Color32, Context, InnerResponse, Order, Pos2, Rect, Response, Sense,
-    TextWrapMode, Ui, Vec2, WidgetInfo, Window,
+    TextWrapMode, Ui, Vec2, Window,
 };
 use epaint::Shadow;
 
@@ -390,7 +390,7 @@ pub fn basic_editor_popup(
         };
     }
     EditorRenderReturn {
-        delete: delete,
+        delete,
         resp: Some(vec![activator_resp]),
     }
 }

--- a/src/gui_egui/helper.rs
+++ b/src/gui_egui/helper.rs
@@ -1,8 +1,9 @@
 use crate::common::{Components, EguiComponent, Input, Ports, SignalValue, Simulator};
-use crate::gui_egui::editor::{EditorMode, SnapPriority};
+use crate::gui_egui::component_ui::input_selector;
+use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, SnapPriority};
+use crate::gui_egui::EguiExtra;
 use egui::{
-    Align2, Area, Color32, Context, InnerResponse, Order, Pos2, Rect, Response, Sense,
-    TextWrapMode, Ui, Vec2,
+    Align2, Area, Color32, Context, InnerResponse, Order, Pos2, Rect, Response, Sense, TextWrapMode, Ui, Vec2, WidgetInfo, Window
 };
 use epaint::Shadow;
 
@@ -123,7 +124,8 @@ pub fn component_area<R>(
         .current_pos(pos)
         .movable(false)
         .enabled(true)
-        .interactable(false)
+        .interactable(true)
+        .sense(Sense::all())
         .pivot(Align2::CENTER_CENTER)
         .constrain(false)
         .show(ctx, content)
@@ -137,7 +139,7 @@ pub fn component_area<R>(
 /// # Arguments
 /// - size: if size is (0f32,0f32) the component will be as large as its content
 /// - content: Note the function don't size the components,
-/// that is the responsibility of the content closure
+///   that is the responsibility of the content closure
 /// - on_hover: if this is some this overides the on hover function and displays that instead
 ///
 /// # Example
@@ -247,7 +249,7 @@ pub fn basic_component_gui_with_on_hover(
                 .response
         },
     )
-    .inner;
+    .response;
 
     r.clone().on_hover_ui(on_hover);
     Some(vec![r])
@@ -308,4 +310,86 @@ pub fn basic_on_hover(
             ));
         }
     };
+}
+
+/// basic editor popup
+/// TODO test me and write documentation
+pub fn basic_editor_popup(
+    component: &mut dyn EguiComponent,
+    ui: &mut Ui,
+    context: &mut EguiExtra,
+    id_ports: &[(crate::common::Id, Ports)],
+    activator_resp: Response,
+    extra_properties_window_stuff: impl FnOnce(&mut Ui), // TODO rename to something better
+) -> EditorRenderReturn {
+    // if we clicked the activator response and sould open a properties window
+    let properties_window = activator_resp.clicked_by(egui::PointerButton::Secondary);
+    // shul component be deleted
+    let mut delete = false;
+
+    // either clicked or windows was open last frame (from egui extra)
+    if properties_window || context.properties_window {
+        // dont close properties when dropdown is active
+        let mut clicked_dropdown = false;
+
+        // crete a window for our properties
+        let resp = Window::new(format!("Properties: {}", component.get_id_ports().0))
+            .frame(
+                egui::containers::Frame::new()
+                    .inner_margin(10)
+                    .corner_radius(10)
+                    .shadow(shadow_small_dark())
+                    .fill(ui.visuals().panel_fill)
+                    .stroke(ui.visuals().window_stroke),
+            )
+            .default_pos(Pos2::from(component.get_pos()))
+            .show(ui.ctx(), |ui| {
+                // TODO make it possible to change id
+                // currently this is not possible as EguiComponent don't implements a way to do this
+
+                // show user properties window stuff
+                extra_properties_window_stuff(ui);
+
+                // Change position
+                let (mut x, mut y) = component.get_pos();
+                ui.horizontal(|ui| {
+                    ui.label("pos x");
+                    ui.add(egui::DragValue::new(&mut x).speed(0.5));
+                    ui.label("pos y");
+                    ui.add(egui::DragValue::new(&mut y).speed(0.5));
+                });
+                component.set_pos((x, y));
+
+                // get inputs to the component and lop over them to create a select input
+                for port in component.get_id_ports().1.inputs {
+                    // for this port create input selector and up date our port
+                    ui.horizontal(|ui| {
+                        let mut new_input = port.input.clone();
+                        clicked_dropdown |= input_selector(
+                            ui,
+                            &mut new_input,
+                            port.port_id.clone(),
+                            id_ports,
+                            component.get_id_ports().0,
+                        );
+                        component.set_id_port(port.port_id.clone(), new_input);
+                    });
+                }
+
+                delete = ui.button("Delete Component").clicked()
+            });
+
+        // if context haven't set properties window on this obj
+        // set it to true so it stays up next frame
+        if !context.properties_window {
+            context.properties_window = true;
+        // im scared of this unwrap, can we grantee that the window is open?
+        } else if !clicked_dropdown && resp.unwrap().response.clicked_elsewhere() {
+            context.properties_window = false;
+        };
+    }
+    EditorRenderReturn {
+        delete: delete,
+        resp: Some(vec![activator_resp]),
+    }
 }

--- a/src/gui_egui/helper.rs
+++ b/src/gui_egui/helper.rs
@@ -3,7 +3,8 @@ use crate::gui_egui::component_ui::input_selector;
 use crate::gui_egui::editor::{EditorMode, EditorRenderReturn, SnapPriority};
 use crate::gui_egui::EguiExtra;
 use egui::{
-    Align2, Area, Color32, Context, InnerResponse, Order, Pos2, Rect, Response, Sense, TextWrapMode, Ui, Vec2, WidgetInfo, Window
+    Align2, Area, Color32, Context, InnerResponse, Order, Pos2, Rect, Response, Sense,
+    TextWrapMode, Ui, Vec2, WidgetInfo, Window,
 };
 use epaint::Shadow;
 


### PR DESCRIPTION
This PR fixes wire in editor mode by making sure the response is in Order::Middle to ensure that clicks are registered.

It also adds an editor_basic_popup helper function that adds the most common functionality in a popup. such as changing inputs and position (and deletion of component).

this function is also added to most components that use basic_component_gui