### PR TITLE
Unclock improvments and simulator reset during start

### DIFF
--- a/mips-lib/src/components/mips_reg_file.rs
+++ b/mips-lib/src/components/mips_reg_file.rs
@@ -162,7 +162,7 @@ impl Component for RegFile {
         Ok(())
     }
 
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         if let Some(last_op) = self.history.borrow_mut().pop() {
             let mut regs = self.registers.borrow_mut();
             if regs[last_op.addr as usize] != last_op.data {

--- a/mips-lib/src/components/physical_mem.rs
+++ b/mips-lib/src/components/physical_mem.rs
@@ -7,7 +7,7 @@ use std::{
     path::PathBuf,
 };
 use syncrim::{
-    common::{Component, Ports},
+    common::{Component, Ports, Simulator},
     signal::Id,
 };
 
@@ -60,7 +60,7 @@ impl Component for PhysicalMem {
         self
     }
 
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         *self.cycle.borrow_mut() -= 1;
         if let Some(op) = self.history.borrow_mut().remove(&*self.cycle.borrow()) {
             self.mem.borrow_mut().revert(op);

--- a/riscv/src/components/clic.rs
+++ b/riscv/src/components/clic.rs
@@ -684,7 +684,7 @@ impl Component for CLIC {
         Ok(())
     }
 
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         // TODO: Add super-clic stack ops
         let mut entry = self.history.borrow_mut().pop().unwrap();
         if let Some(mut ops) = entry.csr_op {

--- a/riscv/src/components/mem.rs
+++ b/riscv/src/components/mem.rs
@@ -461,7 +461,7 @@ impl Component for RVMem {
         Ok(())
     }
 
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         let entry = self.history.borrow_mut().pop().unwrap();
         if let Some(d) = entry.data {
             self.memory.write(

--- a/riscv/src/components/reg_file.rs
+++ b/riscv/src/components/reg_file.rs
@@ -471,7 +471,7 @@ impl Component for RegFile {
         Ok(())
     }
 
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         //println!("unclock");
         let regop = self.history.0.borrow_mut().pop().unwrap();
         let mut regstore = self.registers.borrow_mut();

--- a/src/common.rs
+++ b/src/common.rs
@@ -108,7 +108,7 @@ pub trait Component {
         Ok(())
     }
     /// update component internal state
-    fn un_clock(&self) {}
+    fn un_clock(&self, _simulator: &Simulator) {}
     /// reset component internal state to initial value
     fn reset(&self) {}
 

--- a/src/components/probe_edit.rs
+++ b/src/components/probe_edit.rs
@@ -59,7 +59,7 @@ impl Component for ProbeEdit {
     }
 
     // reverse simulation, notice does not touch simulator state, its just internal
-    fn un_clock(&self) {
+    fn un_clock(&self, _: &Simulator) {
         let mut edit_history = self.edit_history.write().unwrap();
         trace!("{} history {:?}", self.id, edit_history);
         let _next = edit_history.pop().unwrap(); // pop the next editable value

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -197,7 +197,7 @@ impl Simulator {
         };
 
         trace!("sim_state {:?}", simulator.sim_state);
-        simulator.clock();
+        simulator.reset();
         Ok(simulator)
     }
 

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -473,8 +473,9 @@ impl Simulator {
                 _ => self.running_state = RunningState::Stopped,
             };
 
-            for component in self.ordered_components.clone() {
-                component.un_clock();
+            // reverse eval order before uncloak
+            for component in self.ordered_components.clone().into_iter().rev() {
+                component.un_clock(&self);
             }
         }
     }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -475,7 +475,7 @@ impl Simulator {
 
             // reverse eval order before uncloak
             for component in self.ordered_components.clone().into_iter().rev() {
-                component.un_clock(&self);
+                component.un_clock(self);
             }
         }
     }


### PR DESCRIPTION
This PR adds the Simulator as a parameter to the unclock method of components, changing its signature to ``unclock(&self, sim: &Simulator)``. This allows components to access their inputs and outputs during the undo cycle, simplifying state management and enabling easier reversion of state when needed.

unclock is also called in the reverse order compared to clock

Additionally, when a simulator is created using new, it automatically calls reset on all components. This reset call can be used to set initial values, define signal formats, and perform any other necessary setup.